### PR TITLE
Track column lineage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length=100

--- a/sqllineage/combiners.py
+++ b/sqllineage/combiners.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Set, Iterable
+from typing import Iterable, Set
 
 import networkx as nx
 from networkx import DiGraph

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -118,10 +118,7 @@ class LineageAnalyzer:
                 self._extract_from_dml(sub_token)
 
             if sub_token.ttype in Keyword:
-                if any(
-                    re.match(regex, sub_token.normalized)
-                    for regex in SOURCE_TABLE_TOKENS
-                ):
+                if any(re.match(regex, sub_token.normalized) for regex in SOURCE_TABLE_TOKENS):
                     source_table_token_flag = True
                 elif sub_token.normalized in TARGET_TABLE_TOKENS:
                     target_table_token_flag = True

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from typing import Set, TYPE_CHECKING, Tuple, List, Dict
+from typing import Dict, List, Set, TYPE_CHECKING, Tuple
 
 import networkx as nx
 from sqlparse.sql import (
@@ -19,7 +19,7 @@ from sqlparse.tokens import Keyword, Token
 
 # from sqllineage.combiners import combine_columns
 from sqllineage.exceptions import SQLLineageException
-from sqllineage.models import Table, Column
+from sqllineage.models import Column, Table
 
 
 SOURCE_TABLE_TOKENS = (

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -118,7 +118,10 @@ class LineageAnalyzer:
                 self._extract_from_dml(sub_token)
 
             if sub_token.ttype in Keyword:
-                if any(re.match(regex, sub_token.normalized) for regex in SOURCE_TABLE_TOKENS):
+                if any(
+                    re.match(regex, sub_token.normalized)
+                    for regex in SOURCE_TABLE_TOKENS
+                ):
                     source_table_token_flag = True
                 elif sub_token.normalized in TARGET_TABLE_TOKENS:
                     target_table_token_flag = True

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -1,20 +1,25 @@
+import itertools
 import re
-from typing import Set, TYPE_CHECKING, Tuple
+from typing import Set, TYPE_CHECKING, Tuple, List, Dict
 
+import networkx as nx
 from sqlparse.sql import (
+    Case,
     Comment,
     Comparison,
     Function,
     Identifier,
     IdentifierList,
+    Operation,
     Parenthesis,
     Statement,
     TokenList,
 )
 from sqlparse.tokens import Keyword, Token
 
+# from sqllineage.combiners import combine_columns
 from sqllineage.exceptions import SQLLineageException
-from sqllineage.models import Table
+from sqllineage.models import Table, Column
 
 
 SOURCE_TABLE_TOKENS = (
@@ -23,10 +28,15 @@ SOURCE_TABLE_TOKENS = (
     r"((LEFT\s+|RIGHT\s+|FULL\s+)?(INNER\s+|OUTER\s+|STRAIGHT\s+)?|(CROSS\s+|NATURAL\s+)?)?JOIN",
 )
 TARGET_TABLE_TOKENS = ("INTO", "OVERWRITE", "TABLE", "VIEW")
+# TEMP_TABLE_TOKENS = ("WITH(?!.+?SCHEMA BIND.+?)",)
 TEMP_TABLE_TOKENS = ("WITH",)
+TARGET_COLUMN_TOKENS = ("SELECT",)
+# Partial list of unhandled tokens:
+#   AND, AS, CREATE, DESC, EXISTS, FULL, IF, INSERT, NOT, ON, OR, PARTITION,
+#   SHOW, UNION, UNION ALL, VALUES, WHERE,
 
 
-class LineageResult:
+class DataSetLineage:
     """
     Statement Level Lineage Result.
 
@@ -40,7 +50,7 @@ class LineageResult:
     This is the most atomic representation of lineage result.
     """
 
-    __slots__ = ["read", "write", "rename", "drop", "intermediate"]
+    __slots__ = ["read", "write", "rename", "drop", "intermediate", "columns"]
     if TYPE_CHECKING:
         read = write = drop = intermediate = set()  # type: Set[Table]
         rename = set()  # type: Set[Tuple[Table, Table]]
@@ -50,11 +60,9 @@ class LineageResult:
             setattr(self, attr, set())
 
     def __add__(self, other):
-        lineage_result = LineageResult()
+        lineage_result = DataSetLineage()
         for attr in self.__slots__:
-            setattr(
-                lineage_result, attr, getattr(self, attr).union(getattr(other, attr))
-            )
+            setattr(lineage_result, attr, getattr(self, attr).union(getattr(other, attr)))
         return lineage_result
 
     def __str__(self):
@@ -66,14 +74,35 @@ class LineageResult:
     def __repr__(self):
         return str(self)
 
+    def __bool__(self):
+        return any(getattr(self, s) for s in self.__slots__)
+
 
 class LineageAnalyzer:
     """SQL Statement Level Lineage Analyzer."""
 
     def __init__(self) -> None:
-        self._lineage_result = LineageResult()
+        self._lineage_result = DataSetLineage()
 
-    def analyze(self, stmt: Statement) -> LineageResult:
+        self._clause_tokens = {
+            "select": TARGET_COLUMN_TOKENS,
+            "source": SOURCE_TABLE_TOKENS,
+            "target": TARGET_TABLE_TOKENS,
+            "temp": TEMP_TABLE_TOKENS,
+        }
+        self._clause_methods = {
+            "select": self._handle_target_column_token,
+            "source": self._handle_source_table_token,
+            "target": self._handle_target_table_token,
+            "temp": self._handle_temp_table_token,
+        }
+
+        # _columns is kept as a separate list because the incomplete Identifiers are added
+        # there until they can be "fully qualified" and put into _columns_graph.
+        self._columns = []
+        self._columns_graph = nx.DiGraph()
+
+    def analyze(self, stmt: Statement) -> Tuple[DataSetLineage, nx.DiGraph]:
         """
         to analyze the Statement and store the result into :class:`LineageResult`.
 
@@ -93,12 +122,12 @@ class LineageAnalyzer:
         else:
             # DML parsing logic also applies to CREATE DDL
             self._extract_from_dml(stmt)
-        return self._lineage_result
+            self._columns_build_network()
+
+        return self._lineage_result, self._columns_graph
 
     def _extract_from_ddl_drop(self, stmt: Statement) -> None:
-        for table in {
-            Table.create(t) for t in stmt.tokens if isinstance(t, Identifier)
-        }:
+        for table in {Table.create(t) for t in stmt.tokens if isinstance(t, Identifier)}:
             self._lineage_result.drop.add(table)
 
     def _extract_from_ddl_alter(self, stmt: Statement) -> None:
@@ -109,6 +138,7 @@ class LineageAnalyzer:
 
     def _extract_from_dml(self, token: Token) -> None:
         table_cmd_stack = []
+        unhandled_stack = []
 
         for tn, sub_token in enumerate(token.tokens):
             if self.__token_negligible_before_tablename(sub_token):
@@ -117,31 +147,31 @@ class LineageAnalyzer:
             if isinstance(sub_token, TokenList):
                 self._extract_from_dml(sub_token)
                 # There is no continue here because things like table names are inside a TokenList,
-                # so _extract_from_dml() will do nothing, after which the methods below will execute.
+                # so _extract_from_dml() will do nothing, after which the logic below will execute.
 
             if sub_token.ttype in Keyword:
-                if any(
-                    re.match(regex, sub_token.normalized)
-                    for regex in SOURCE_TABLE_TOKENS
-                ):
-                    table_cmd_stack.append("SOURCE")
-                elif sub_token.normalized in TARGET_TABLE_TOKENS:
-                    if not table_cmd_stack or table_cmd_stack[-1] != "TARGET":
-                        table_cmd_stack.append("TARGET")
-                elif sub_token.normalized in TEMP_TABLE_TOKENS:
-                    table_cmd_stack.append("TEMP")
+                for k, v in self._clause_tokens.items():
+                    if any(re.match(regex, sub_token.normalized) for regex in v):
+                        # Sometimes multiple matching operators exist for a single clause--don't add extras.
+                        if not table_cmd_stack or table_cmd_stack[-1] != k:
+                            table_cmd_stack.append(k)
+                        break
+                else:
+                    unhandled_stack.append(sub_token.normalized)
                 continue
 
             if not len(table_cmd_stack):
+                # print(type(sub_token), sub_token, "    whole: ", token)
                 continue
 
-            cmd = table_cmd_stack.pop()
-            if cmd == "SOURCE":
-                self._handle_source_table_token(sub_token)
-            elif cmd == "TARGET":
-                self._handle_target_table_token(sub_token)
-            elif cmd == "TEMP":
-                self._handle_temp_table_token(sub_token)
+            # noinspection PyArgumentList
+            self._clause_methods[table_cmd_stack.pop()](sub_token)
+
+        # if unhandled_stack:
+        #     print("Unhandled: ", unhandled_stack)
+
+        if table_cmd_stack:
+            raise SQLLineageException(f"Clause keywords without content: {table_cmd_stack}")
 
     def _handle_source_table_token(self, sub_token: Token) -> None:
         if isinstance(sub_token, Identifier):
@@ -162,52 +192,182 @@ class LineageAnalyzer:
             # This syntax without alias for subquery is invalid in MySQL, while valid for SparkSQL
             pass
         else:
-            raise SQLLineageException(
-                "An Identifier is expected, got %s[value: %s] instead"
-                % (type(sub_token).__name__, sub_token)
-            )
+            self._raise_identifier_exception(sub_token)
 
     def _handle_target_table_token(self, sub_token: Token) -> None:
         if isinstance(sub_token, Function):
             # insert into tab (col1, col2) values (val1, val2); Here tab (col1, col2) will be parsed as Function
             # referring https://github.com/andialbrecht/sqlparse/issues/483 for further information
             if not isinstance(sub_token.token_first(skip_cm=True), Identifier):
-                raise SQLLineageException(
-                    "An Identifier is expected, got %s[value: %s] instead"
-                    % (type(sub_token).__name__, sub_token)
-                )
-            self._lineage_result.write.add(
-                Table.create(sub_token.token_first(skip_cm=True))
-            )
+                self._raise_identifier_exception(sub_token)
+            self._lineage_result.write.add(Table.create(sub_token.token_first(skip_cm=True)))
         elif isinstance(sub_token, Comparison):
             # create table tab1 like tab2, tab1 like tab2 will be parsed as Comparison
             # referring https://github.com/andialbrecht/sqlparse/issues/543 for further information
             if not (
-                isinstance(sub_token.left, Identifier)
-                and isinstance(sub_token.right, Identifier)
+                isinstance(sub_token.left, Identifier) and isinstance(sub_token.right, Identifier)
             ):
-                raise SQLLineageException(
-                    "An Identifier is expected, got %s[value: %s] instead"
-                    % (type(sub_token).__name__, sub_token)
-                )
+                self._raise_identifier_exception(sub_token)
             self._lineage_result.write.add(Table.create(sub_token.left))
             self._lineage_result.read.add(Table.create(sub_token.right))
         else:
             if not isinstance(sub_token, Identifier):
-                raise SQLLineageException(
-                    "An Identifier is expected, got %s[value: %s] instead"
-                    % (type(sub_token).__name__, sub_token)
-                )
+                self._raise_identifier_exception(sub_token)
             self._lineage_result.write.add(Table.create(sub_token))
 
     def _handle_temp_table_token(self, sub_token: Token) -> None:
         if not isinstance(sub_token, Identifier):
-            raise SQLLineageException(
-                "An Identifier is expected, got %s[value: %s] instead"
-                % (type(sub_token).__name__, sub_token)
-            )
+            self._raise_identifier_exception(sub_token)
+        if sub_token.normalized == "BINDING":  # Ignore view clause "WITH NO SCHEMA BINDING"
+            return
         self._lineage_result.intermediate.add(Table.create(sub_token))
         self._extract_from_dml(sub_token)
+
+    def _handle_target_column_token(self, sub_token: Token) -> None:
+        not_identifier = (",", "1", "*")
+
+        if not isinstance(sub_token, IdentifierList):
+            sub_token = [sub_token]
+
+        for st in sub_token:
+            # Functions aren't handled. Yet.
+            if isinstance(st, Function):
+                continue
+            # No information here
+            if st.is_whitespace or st.normalized in not_identifier:
+                continue
+            if isinstance(st, IdentifierList):
+                print("Complex expressions aren't handled")
+                continue
+            if st.ttype in Token.Keyword:
+                print("Complex expressions aren't handled")
+                continue
+            if st.ttype in Token.Literal:
+                # This shouldn't happen but sometimes it does anyway due to weird SQL
+                continue
+            if not isinstance(st, Identifier):
+                self._raise_identifier_exception(sub_token)
+            self._columns.append(st)
+
+    def _columns_build_network(self) -> None:
+        """Build out a DiGraph from the columns information
+
+        This is used rather than a DataSetLineage as with table names because
+        the relations are more complex and would require a separate Lineage
+        object to be created for every column.  Rather than doing that,
+        a graph object handling the relationships is built right away.
+        """
+        # Get the source table aliases
+        table_mapping = self._build_table_mapping()
+        for c in self._columns:
+            sources, target = self._columns_get_sources_target(c, table_mapping)
+            self._columns_graph.add_nodes_from(sources, source=True)
+            self._columns_graph.add_node(target, target=True)
+            for src, tgt in itertools.product(sources, [target]):
+                self._columns_graph.add_edge(src, tgt)
+
+    @staticmethod
+    def _columns_get_sources_target(column: Identifier, tables: Dict) -> Tuple[List, Column]:
+        parent_table = (
+            tables[column.get_parent_name()]
+            if column.get_parent_name() in tables
+            else Table("unknown")
+        )
+        if not column.has_alias():
+            # If there is no alias then the source and target columns names are the same.
+            # Create a mapping from the column parent name (source table) to the target
+            # if column.get_parent_name() not in tables:
+            #     raise KeyError(f"Unknown table {column.get_parent_name()} for column {str(column)}")
+            return [Column(column.get_name(), parent_table)], Column(
+                column.get_name(), tables[None]
+            )
+        else:
+            # This is a simple column with an alias, e.g. "schema.table.field1 as field"
+            if column[0].ttype is Token.Name:
+                return [Column(column.get_real_name(), parent_table)], Column(
+                    column.get_alias(), tables[None]
+                )
+            # Source is a function
+            elif isinstance(column[0], Function):
+                # print("Functions are unhandled")
+                cols = LineageAnalyzer._extract_source_columns(column[0], skip=1)
+                cols = [Column(c.get_name(), tables[c.get_parent_name()]) for c in cols]
+                # try:
+                #     cols = [Column(c.get_name(), tables[c.get_parent_name()]) for c in cols]
+                # except KeyError as e:
+                #     print(f"Missing table {e} so skipping source {column[0]}")
+                #     return [], Column(column.get_alias(), tables[None])
+                return cols, Column(column.get_alias(), tables[None])
+                # return [Column("FUNCTION", Table("unknown"))], Column(column.get_alias(), tables[None])
+            # Source is an operation
+            elif isinstance(column[0], Operation):
+                print("Operations are unhandled")
+                return [Column("OPERATION", Table("unknown"))], Column(
+                    column.get_alias(), tables[None]
+                )
+            # Source is a case statement
+            elif isinstance(column[0], Case):
+                print("Case statements are unhandled")
+                return [Column("CASE", Table("unknown"))], Column(column.get_alias(), tables[None])
+            # Source is a literal
+            elif column[0].ttype in Token.Literal:
+                return [Column("LITERAL", Table("unknown"))], Column(
+                    column.get_alias(), tables[None]
+                )
+            # Shouldn't get here
+            else:
+                raise SQLLineageException(f"Unhandled column string: {column}")
+
+    @staticmethod
+    def _extract_source_columns(token: Token, skip=0) -> List:
+        # print(str(token))
+        columns = []
+        for t in token[skip:]:
+            if isinstance(t, Identifier):
+                columns.append(t)
+                continue
+            elif t.ttype is Token.Punctuation:
+                continue
+            elif t.is_group:
+                columns.extend(
+                    LineageAnalyzer._extract_source_columns(
+                        t, skip=1 if isinstance(t, Function) else 0
+                    )
+                )
+        return columns
+
+    def _build_table_mapping(self) -> Dict:
+        def _mapping_helper(table: Table):
+            # Note that if there are conflicting 'raw_name's where tables have the
+            # same name in different schemas, then this can be broken depending
+            # on how the DML uses aliases.  But it should work in most cases.
+            m = {
+                table.raw_name: table,
+                str(table): table,
+            }
+            if table.alias:
+                m[table.alias] = table
+            return m
+
+        mapping = {}
+        # Targets first (this is on purpose because the first target table will be used if no specifier is given)
+        for tgt in self._lineage_result.write:
+            mapping.update(_mapping_helper(tgt))
+        for tmp in self._lineage_result.intermediate:
+            mapping.update(_mapping_helper(tmp))
+        for src in self._lineage_result.read:
+            mapping.update(_mapping_helper(src))
+        # Make the None key map to whatever table was added first
+        if mapping:
+            mapping[None] = mapping[next(iter(mapping))]
+        return mapping
+
+    @staticmethod
+    def _raise_identifier_exception(sub_token):
+        raise SQLLineageException(
+            "An Identifier is expected, got %s[value: %s] instead"
+            % (type(sub_token).__name__, sub_token)
+        )
 
     @classmethod
     def __token_negligible_before_tablename(cls, token: Token) -> bool:

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -202,7 +202,7 @@ class LineageAnalyzer:
 
             if sub_token.ttype in Keyword:
                 for k, v in self._clause_tokens.items():
-                    if any(re.match(regex, sub_token.normalized) for regex in v):  # type: ignore
+                    if any(re.match(regex, sub_token.normalized) for regex in v):
                         # Sometimes multiple matching operators exist for a single clause--don't add extras.
                         if not table_cmd_stack or table_cmd_stack[-1] != k:
                             table_cmd_stack.append(k)

--- a/sqllineage/drawing.py
+++ b/sqllineage/drawing.py
@@ -21,11 +21,13 @@ def draw_lineage_graph(graph: DiGraph) -> None:
         import pygraphviz  # noqa
     except ImportError as e:
         raise ImportError("requires pygraphviz") from e
+
     pos = nx.nx_agraph.graphviz_layout(graph, prog="dot", args="-Grankdir='LR'")
     edge_color, node_color, font_color = "#9ab5c7", "#3499d9", "#35393e"
     arrowsize = font_size = radius = 10
     node_size = 30
     ha, va = "left", "bottom"
+
     nx.draw(
         graph,
         pos=pos,
@@ -39,6 +41,7 @@ def draw_lineage_graph(graph: DiGraph) -> None:
         horizontalalignment=ha,
         verticalalignment=va,
     )
+
     # selfloop edges
     for edge in nx.selfloop_edges(graph):
         x, y = pos[edge[0]]
@@ -51,4 +54,81 @@ def draw_lineage_graph(graph: DiGraph) -> None:
             zorder=1,
         )
         plt.gca().add_patch(arrow)
+
+    plt.show()
+
+
+def draw_lineage_graph2(graph: DiGraph) -> None:
+    try:
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import colorConverter
+        from matplotlib.patches import FancyArrowPatch
+        from matplotlib.path import Path
+    except ImportError as e:
+        raise ImportError("Matplotlib required for draw()") from e
+    except RuntimeError:
+        logger.error("Matplotlib unable to open display")
+        raise
+    try:
+        import pygraphviz  # noqa
+    except ImportError as e:
+        raise ImportError("requires pygraphviz") from e
+
+    _color_source = "#75ff33"
+    _color_target = "#ff5733"
+    _color_both = "#bd33ff"
+    _color_neither = "#33dbff"
+
+    sources = [k for k, v in nx.get_node_attributes(graph, "source").items() if v]
+    targets = [k for k, v in nx.get_node_attributes(graph, "target").items() if v]
+    color_map = []
+    for node in graph:
+        if node in sources:
+            if node in targets:
+                color_map.append(_color_both)
+            else:
+                color_map.append(_color_source)
+        else:
+            if node in targets:
+                color_map.append(_color_target)
+            else:
+                color_map.append(_color_neither)
+
+    pos = nx.nx_agraph.graphviz_layout(graph, prog="dot", args="-Grankdir=LR")
+    edge_color, font_color = "#9ab5c7", "#35393e"  # "#3499d9"
+    arrowsize = font_size = radius = 10
+    node_size = 30
+    ha, va = "left", "bottom"
+
+    nx.draw(
+        graph,
+        pos=pos,
+        with_labels=True,
+        edge_color=edge_color,
+        arrowsize=arrowsize,
+        node_color=color_map,
+        node_size=node_size,
+        font_color=font_color,
+        font_size=font_size,
+        horizontalalignment=ha,
+        verticalalignment=va,
+    )
+
+    # # selfloop edges
+    # for edge in nx.selfloop_edges(graph):
+    #     x, y = pos[edge[0]]
+    #     arrow = FancyArrowPatch(
+    #         path=Path.circle((x, y + radius), radius),
+    #         arrowstyle="-|>",
+    #         color=colorConverter.to_rgba_array(edge_color)[0],
+    #         mutation_scale=arrowsize,
+    #         linewidth=1.0,
+    #         zorder=1,
+    #     )
+    #     plt.gca().add_patch(arrow)
+
+    axis = plt.gca()
+    axis.set_xlim([1.2 * x for x in axis.get_xlim()])
+    axis.set_ylim([1.1 * y for y in axis.get_ylim()])
+
     plt.show()

--- a/sqllineage/drawing.py
+++ b/sqllineage/drawing.py
@@ -58,12 +58,13 @@ def draw_lineage_graph(graph: DiGraph) -> None:
     plt.show()
 
 
-def draw_lineage_graph2(graph: DiGraph) -> None:
+def draw_lineage_graph_colors(graph: DiGraph) -> None:
     try:
         import matplotlib.pyplot as plt
-        from matplotlib.colors import colorConverter
-        from matplotlib.patches import FancyArrowPatch
-        from matplotlib.path import Path
+
+        # from matplotlib.colors import colorConverter
+        # from matplotlib.patches import FancyArrowPatch
+        # from matplotlib.path import Path
     except ImportError as e:
         raise ImportError("Matplotlib required for draw()") from e
     except RuntimeError:
@@ -96,7 +97,7 @@ def draw_lineage_graph2(graph: DiGraph) -> None:
 
     pos = nx.nx_agraph.graphviz_layout(graph, prog="dot", args="-Grankdir=LR")
     edge_color, font_color = "#9ab5c7", "#35393e"  # "#3499d9"
-    arrowsize = font_size = radius = 10
+    arrowsize = font_size = 10
     node_size = 30
     ha, va = "left", "bottom"
 
@@ -115,6 +116,7 @@ def draw_lineage_graph2(graph: DiGraph) -> None:
     )
 
     # # selfloop edges
+    # radius = 10
     # for edge in nx.selfloop_edges(graph):
     #     x, y = pos[edge[0]]
     #     arrow = FancyArrowPatch(

--- a/sqllineage/models.py
+++ b/sqllineage/models.py
@@ -34,13 +34,15 @@ class Schema:
 
 
 class Table:
-    def __init__(self, name: str, schema: Schema = Schema()):
+    def __init__(self, name: str, schema: Schema = Schema(), alias: str = None):
         """
         Data Class for Table
 
         :param name: table name
         :param schema: schema as defined by :class:`Schema`
         """
+        self.alias = alias
+
         if len(name.split(".")) == 2:
             schema_name, table_name = name.split(".")
             self.schema = Schema(schema_name)
@@ -72,7 +74,7 @@ class Table:
             if identifier.get_parent_name() is not None
             else Schema()
         )
-        return Table(identifier.get_real_name(), schema)
+        return Table(identifier.get_real_name(), schema, identifier.get_alias())
 
 
 class Partition:
@@ -80,4 +82,82 @@ class Partition:
 
 
 class Column:
-    pass
+    def __init__(self, name: str, parent: Table, alias: str = None):
+        """
+        Data Class for Schema
+
+        :param name: schema name
+        """
+        self.name = escape_identifier_name(name)
+        self.parent = parent
+        self.alias = escape_identifier_name(alias) if alias else None
+
+    def __str__(self):
+        return self.name.lower() if not self.parent else str(self.parent) + "." + self.name.lower()
+
+    def __repr__(self):
+        if not self.alias:
+            return "Column: " + str(self)
+        else:
+            return "Aliased column: " + str(self) + " as " + self.alias.lower()
+
+    def __eq__(self, other):
+        return type(self) is type(other) and str(self) == str(other)
+
+    def __hash__(self):
+        return hash(str(self))
+
+    # def __bool__(self):
+    #     return str(self) != self.unknown
+
+    # @staticmethod
+    # def create(identifier: Identifier):
+    #     return Column(
+    #         identifier.get_real_name(), identifier.get_alias(), identifier.get_parent_name()
+    #     )
+
+
+# class DataSet:
+#     def __init__(self, name: str, schema: Schema = Schema()):
+#         class_name = self.__class__.__name__.lower()
+#         if len(name.split(".")) == 2:
+#             schema_name, table_name = name.split(".")
+#             self.schema = Schema(schema_name)
+#             self.raw_name = table_name
+#             if schema:
+#                 warnings.warn("Name is in schema.{} format, schema param is ignored".format(class_name))
+#         elif "." not in name:
+#             self.schema = schema
+#             self.raw_name = name
+#         else:
+#             raise SQLLineageException("Invalid format for {} name: {}".format(class_name, name))
+#
+#     def __str__(self):
+#         return "{}.{}".format(self.schema, self.raw_name.lower())
+#
+#     def __repr__(self):
+#         return self.__class__.__name__ + ": " + str(self)
+#
+#     def __eq__(self, other):
+#         return type(self) is type(other) and str(self) == str(other)
+#
+#     def __hash__(self):
+#         return hash(str(self))
+#
+#     @staticmethod
+#     def create(identifier: Identifier, is_view=False):
+#         schema = (
+#             Schema(identifier.get_parent_name())
+#             if identifier.get_parent_name() is not None
+#             else Schema()
+#         )
+#         clazz = View if is_view else Table
+#         return clazz(identifier.get_real_name(), schema)
+#
+#
+# class Table(DataSet):
+#     pass
+#
+#
+# class View(DataSet):
+#     pass

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -4,8 +4,8 @@ from typing import List
 
 import networkx
 import sqlparse
-from sqlparse.sql import Statement
 from networkx import DiGraph, write_gml
+from sqlparse.sql import Statement
 
 from sqllineage import drawing
 from sqllineage.combiners import combine_datasets

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
-from sqllineage.core import LineageResult
+from sqllineage.core import DataSetLineage
 
 
 def test_dummy():
-    assert str(LineageResult()) == repr(LineageResult())
-    assert LineageResult() + LineageResult() is not None
+    assert str(DataSetLineage()) == repr(DataSetLineage())
+    assert DataSetLineage() + DataSetLineage() is not None

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -16,6 +16,16 @@ def test_insert_without_table():
 
 def test_with_cte_without_table():
     with pytest.raises(SQLLineageException):
-        LineageRunner(
-            "with as select * from foo insert into table bar select * from foo"
-        )
+        LineageRunner("with as select * from foo insert into table bar select * from foo")
+
+
+def test_clause_keyword_after_select():
+    with pytest.raises(SQLLineageException):
+        LineageRunner("select table as my_column from tab1")
+
+
+# def test_table_alias_bad():
+#     with pytest.raises(KeyError):
+#         LineageRunner("select bad.column from tab1")
+#     # with pytest.raises(KeyError):
+#     #     LineageRunner("select bad.column as col from tab1")

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -42,15 +42,13 @@ def test_insert_overwrite_with_keyword_table():
 
 
 def test_insert_overwrite_values():
-    helper(
-        "INSERT OVERWRITE tab1 VALUES ('val1', 'val2'), ('val3', 'val4')", {}, {"tab1"}
-    )
+    helper("INSERT OVERWRITE tab1 VALUES ('val1', 'val2'), ('val3', 'val4')", {}, {"tab1"})
 
 
 def test_insert_overwrite_from_self():
     helper(
         """INSERT OVERWRITE TABLE tab_1
-SELECT tab2.col_a from tab_2
+SELECT tab_2.col_a from tab_2
 JOIN tab_1
 ON tab_1.col_a = tab_2.cola""",
         {"tab_1", "tab_2"},

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -50,9 +50,15 @@ def test_select_with_comment_after_from():
 
 
 def test_select_with_comment_after_join():
-    helper(
-        "select * from tab1 join --comment\ntab2 on tab1.x = tab2.x", {"tab1", "tab2"}
-    )
+    helper("select * from tab1 join --comment\ntab2 on tab1.x = tab2.x", {"tab1", "tab2"})
+
+
+def test_select_multiple_column_alias():
+    helper("select column1 as c1, column2 as c2 from tab1", {"tab1"})
+
+
+def test_select_column_alias():
+    helper("select column1 as c1 from tab1", {"tab1"})
 
 
 def test_select_keyword_as_column_alias():
@@ -123,9 +129,7 @@ def test_select_cross_join():
 
 
 def test_select_cross_join_with_on():
-    helper(
-        "SELECT * FROM tab1 CROSS JOIN tab2 on tab1.col1 = tab2.col2", {"tab1", "tab2"}
-    )
+    helper("SELECT * FROM tab1 CROSS JOIN tab2 on tab1.col1 = tab2.col2", {"tab1", "tab2"})
 
 
 def test_select_join_with_subquery():


### PR DESCRIPTION
These changes may or may not be suitable upstream since core.py is heavily modified.  
The handling is changed to be able to allow tracing lineage of columns in addition to that of tables/fields.  Also adds the ability to serialize the table / column graphs to GML files for view in external programs.

Please feel free to make edits if this is something that can be merged upstream with modification.