### PR TITLE
fix: for Spark bucket table DDL bucket being parsed as table name

### DIFF
--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -11,6 +11,7 @@ from sqlparse.sql import (
     Statement,
     TokenList,
 )
+from sqlparse.tokens import Number
 
 from sqllineage.exceptions import SQLLineageException
 from sqllineage.models import Table
@@ -193,7 +194,11 @@ class LineageAnalyzer:
                     "An Identifier is expected, got %s[value: %s] instead"
                     % (type(sub_token).__name__, sub_token)
                 )
-            self._lineage_result.write.add(Table.create(sub_token))
+            if sub_token.token_first(skip_cm=True).ttype is Number.Integer:
+                # Special Handling for Spark Bucket Table DDL
+                pass
+            else:
+                self._lineage_result.write.add(Table.create(sub_token))
 
     def _handle_temp_table_token(self, sub_token: TokenList) -> None:
         if not isinstance(sub_token, Identifier):

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -25,6 +25,14 @@ def test_create_if_not_exist():
     helper("CREATE TABLE IF NOT EXISTS tab1 (col1 STRING)", None, {"tab1"})
 
 
+def test_create_bucket_table():
+    helper(
+        "CREATE TABLE tab1 USING parquet CLUSTERED BY (col1) INTO 500 BUCKETS",
+        None,
+        {"tab1"},
+    )
+
+
 def test_create_as():
     helper("CREATE TABLE tab1 AS SELECT * FROM tab2", {"tab2"}, {"tab1"})
 


### PR DESCRIPTION
Closes #111 