### PR TITLE
Parsing of multiple with statments added

### DIFF
--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -202,18 +202,16 @@ class LineageAnalyzer:
 
     def _handle_temp_table_token(self, sub_token: TokenList) -> None:
         if isinstance(sub_token, Identifier):
-            self._lineage_result.intermediate.add(
-                Table.create(sub_token))
+            self._lineage_result.intermediate.add(Table.create(sub_token))
             self._extract_from_dml(sub_token)
         elif isinstance(sub_token, IdentifierList):
             for temp_tab_token in sub_token:
                 if isinstance(temp_tab_token, Identifier):
-                    self._lineage_result.intermediate.add(
-                        Table.create(temp_tab_token))
+                    self._lineage_result.intermediate.add(Table.create(temp_tab_token))
                     self._extract_from_dml(temp_tab_token)
         else:
             raise SQLLineageException(
-                "An Identifier(List) is expected, got %s[value: %s] instead"
+                "An Identifier or IdentifierList is expected, got %s[value: %s] instead"
                 % (type(sub_token).__name__, sub_token)
             )
 

--- a/sqllineage/core.py
+++ b/sqllineage/core.py
@@ -201,13 +201,21 @@ class LineageAnalyzer:
                 self._lineage_result.write.add(Table.create(sub_token))
 
     def _handle_temp_table_token(self, sub_token: TokenList) -> None:
-        if not isinstance(sub_token, Identifier):
+        if isinstance(sub_token, Identifier):
+            self._lineage_result.intermediate.add(
+                Table.create(sub_token))
+            self._extract_from_dml(sub_token)
+        elif isinstance(sub_token, IdentifierList):
+            for temp_tab_token in sub_token:
+                if isinstance(temp_tab_token, Identifier):
+                    self._lineage_result.intermediate.add(
+                        Table.create(temp_tab_token))
+                    self._extract_from_dml(temp_tab_token)
+        else:
             raise SQLLineageException(
-                "An Identifier is expected, got %s[value: %s] instead"
+                "An Identifier(List) is expected, got %s[value: %s] instead"
                 % (type(sub_token).__name__, sub_token)
             )
-        self._lineage_result.intermediate.add(Table.create(sub_token))
-        self._extract_from_dml(sub_token)
 
     @classmethod
     def __token_negligible_before_tablename(cls, token: TokenList) -> bool:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -147,12 +147,16 @@ def test_with_select():
 def test_with_select_one():
     helper(
         "WITH wtab1 AS (SELECT * FROM schema1.tab1) SELECT * FROM wtab1",
-        {"schema1.tab1"})
+        {"schema1.tab1"},
+    )
+
 
 def test_with_select_many():
     helper(
-        "WITH wtab1 AS (SELECT * FROM schema1.tab1), "
-        "wtab2 AS (SELECT * FROM schema2.tab2)"
-        "SELECT * FROM wtab1 JOIN wtab2 ON wtab1.id = wtab2.id",
-        {"schema1.tab1", "schema2.tab2"}
+        "WITH "
+        "  cte1 AS (SELECT a, b FROM table1), "
+        "  cte2 AS (SELECT c, d FROM table2) "
+        "SELECT b, d FROM cte1 JOIN cte2 "
+        "WHERE cte1.a = cte2.c",
+        {"table1", "table2"},
     )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -142,3 +142,17 @@ def test_select_join_in_ansi89_syntax():
 
 def test_with_select():
     helper("WITH tab1 AS (SELECT 1) SELECT * FROM tab1")
+
+
+def test_with_select_one():
+    helper(
+        "WITH wtab1 AS (SELECT * FROM schema1.tab1) SELECT * FROM wtab1",
+        {"schema1.tab1"})
+
+def test_with_select_many():
+    helper(
+        "WITH wtab1 AS (SELECT * FROM schema1.tab1), "
+        "wtab2 AS (SELECT * FROM schema2.tab2)"
+        "SELECT * FROM wtab1 JOIN wtab2 ON wtab1.id = wtab2.id",
+        {"schema1.tab1", "schema2.tab2"}
+    )


### PR DESCRIPTION
The following SQL statement results in an Exception:
```sql
WITH wtab1 AS (SELECT * FROM tab1),
wtab2 AS (SELECT * FROM tab2)
SELECT *
FROM wtab1
```

The reason is that after a with statement an _Identifier_ is assumed. The above example however results in an _IdentifierList_. This pull request addresses this issue by extending *_handle_temp_table_token* to also check for *IdentifierList* and resolving that case as needed.
I also added two new tests.

Last but not least let me thank you for your great work on this project!