### PR TITLE
initialize logging config at main

### DIFF
--- a/sqllineage/__init__.py
+++ b/sqllineage/__init__.py
@@ -1,4 +1,3 @@
-import logging.config
 import os
 
 
@@ -56,7 +55,6 @@ DEFAULT_LOGGING = {
         },
     },
 }
-logging.config.dictConfig(DEFAULT_LOGGING)
 
 STATIC_FOLDER = "build"
 DATA_FOLDER = os.environ.get(

--- a/sqllineage/cli.py
+++ b/sqllineage/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import logging
+import logging.config
 
-from sqllineage import DEFAULT_HOST, DEFAULT_PORT
+
+from sqllineage import DEFAULT_HOST, DEFAULT_LOGGING, DEFAULT_PORT
 from sqllineage.drawing import draw_lineage_graph
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
@@ -16,6 +18,8 @@ def main(args=None) -> None:
 
     :param args: the command line arguments for sqllineage command
     """
+    logging.config.dictConfig(DEFAULT_LOGGING)
+
     parser = argparse.ArgumentParser(
         prog="sqllineage", description="SQL Lineage Parser."
     )


### PR DESCRIPTION
Moving to initialize logging config at entry point of the CLI . This way
if used as a library (imported in another projected) it will not
override the other project logging configuration

Testing Done: Ran tox -e py310 and used pre-commit hook installed
locally.

Signed-off-by: Antoni Ivanov <aivanov@vmware.com>