### PR TITLE
fix: Support Trino bucketing syntax

### DIFF
--- a/sqllineage/core/handlers/cte.py
+++ b/sqllineage/core/handlers/cte.py
@@ -1,4 +1,4 @@
-from sqlparse.sql import Function, Identifier, IdentifierList, Token
+from sqlparse.sql import Function, Identifier, IdentifierList, Parenthesis, Token
 
 from sqllineage.core.handlers.base import NextTokenBaseHandler
 from sqllineage.core.holders import SubQueryLineageHolder
@@ -23,6 +23,11 @@ class CTEHandler(NextTokenBaseHandler):
             cte = [
                 token for token in token.tokens if isinstance(token, cte_token_types)
             ]
+        elif isinstance(token, Parenthesis):
+            # CREATE TABLE tbl1 (col1 VARCHAR) WITH (bucketed_by = ARRAY['col1'], bucket_count = 256).
+            # This syntax is valid for bucketing in Trino and not the CTE
+            self._handle(token.tokens[1], holder)
+            cte = []
         else:
             raise SQLLineageException(
                 "An Identifier or IdentifierList is expected, got %s[value: %s] instead."

--- a/sqllineage/core/handlers/cte.py
+++ b/sqllineage/core/handlers/cte.py
@@ -26,7 +26,6 @@ class CTEHandler(NextTokenBaseHandler):
         elif isinstance(token, Parenthesis):
             # CREATE TABLE tbl1 (col1 VARCHAR) WITH (bucketed_by = ARRAY['col1'], bucket_count = 256).
             # This syntax is valid for bucketing in Trino and not the CTE
-            self._handle(token.tokens[1], holder)
             cte = []
         else:
             raise SQLLineageException(

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -101,6 +101,15 @@ STORED AS TEXTFILE""",  # noqa
     )
 
 
+def test_bucket_with_using_parenthesis():
+    assert_table_lineage_equal(
+        """CREATE TABLE tbl1 (col1 VARCHAR)
+  WITH (bucketed_on = array['col1'], bucket_count = 256);""",
+        None,
+        {"tbl1"},
+    )
+
+
 def test_update():
     assert_table_lineage_equal(
         "UPDATE tab1 SET col1='val1' WHERE col2='val2'", None, {"tab1"}

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     pytest --cov
 
 [flake8]
-exclude = .tox
+exclude = .tox,.git,__pycache__,build,sqllineagejs
 max-line-length = 120
 # ignore = D100,D101
 show-source = true


### PR DESCRIPTION
Since Trino uses WITH for bucketing without Identifier after WITH,
allow Parenthesis after WITH.
https://trino.io/blog/2019/05/29/improved-hive-bucketing.html

Close #251 