### PR TITLE
Add lineage output as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Intermediate Tables:
 ```
 
 ### Column-Level Lineage
-We also support column level lineage in command line interface, set level option to column, all column lineage path will 
-be printed.
+We also support column level lineage in command line interface, set level option to column (`--level=column` flag),
+and all column lineage path will be printed.
 
 ```sql
 INSERT OVERWRITE TABLE foo
@@ -132,6 +132,10 @@ $ sqllineage -f foo.sql -l column
 <default>.foo.col3 <- c.col3_sum <- <default>.qux.col3
 <default>.foo.col4 <- col4
 ```
+
+### JSON Lineage Output
+Both table (regular) and column-level lineage are exportable by the tool, using the `--json-out` flag.
+This flag works with the column-level lineage (`--level=column`) flag too.
 
 ### Lineage Visualization
 One more cool feature, if you want a graph visualization for the lineage result, toggle graph-visualization option

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, List, Tuple
 
@@ -152,18 +153,26 @@ Target Tables:
             key=lambda x: (str(x[-1]), str(x[0])),
         )
 
-    def print_column_lineage(self) -> None:
+    def print_lineage(self, lineage_level, json_out) -> None:
         """
-        print column level lineage to stdout
+        Print lineage to stdout depending on type requested
         """
-        for path in self.get_column_lineage():
-            print(" <- ".join(str(col) for col in reversed(path)))
-
-    def print_table_lineage(self) -> None:
-        """
-        print table level lineage to stdout
-        """
-        print(str(self))
+        if json_out:  # Print lineage in JSON format
+            if lineage_level == LineageLevel.COLUMN:
+                json_data = {
+                    "dag": self.to_cytoscape(),
+                    "column": self.to_cytoscape(LineageLevel.COLUMN),
+                }
+            else:
+                json_data = {"dag": self.to_cytoscape()}
+            print(json.dumps(json_data, indent=None))
+        else:
+            # Print lineage in standard format
+            if lineage_level == LineageLevel.COLUMN:
+                for path in self.get_column_lineage():
+                    print(" <- ".join(str(col) for col in reversed(path)))
+            else:
+                print(str(self))
 
     def _eval(self):
         self._stmt = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 from unittest.mock import patch
 
@@ -36,3 +37,80 @@ def test_file_permission_error(_):
     with pytest.raises(SystemExit) as e:
         main(["-f", __file__])
     assert e.value.code == 1
+
+
+def test_e_and_j_args_exception():
+    with pytest.raises(SystemExit) as e:
+        main(["-g", "-j"])
+    assert e.value.code == 1
+
+
+def sorted_json(item):
+    """
+    Necessary to get working equality comparison between unsorted JSON objects.
+    See here for source: https://www.geeksforgeeks.org/how-to-compare-json-objects-regardless-of-order-in-python/
+    """
+    if isinstance(item, dict):
+        return sorted((key, sorted_json(values)) for key, values in item.items())
+    if isinstance(item, list):
+        return sorted(sorted_json(x) for x in item)
+    else:
+        return item
+
+
+def test_nonjson_cli_output(capfd):
+    """
+    Test that table-level normal CLI lineage output is as expected.
+    """
+    main(["-e", "CREATE VIEW vw1 AS SELECT col1 FROM tab1"])  # Run a trivial lineage
+    # The output we want
+    want = """Statements(#): 1
+Source Tables:
+    <default>.tab1
+Target Tables:
+    <default>.vw1\n\n"""
+    stdout, stderror = capfd.readouterr()  # Capture stdout, stderror
+    # Test that the lineage output we have is the lineage we want
+    assert stdout == want
+
+
+def test_json_cli_output(capfd):
+    """
+    Test that table-level json CLI lineage output is as expected.
+    """
+    main(
+        ["--json", "-e", "CREATE VIEW vw1 AS SELECT col1 FROM tab1"]
+    )  # Run a trivial lineage
+    # The output we want
+    want = '{"dag": [{"data": {"id": "<default>.tab1"}}, {"data": {"id": "<default>.vw1"}}, {"data": {"id": "e0", "source": "<default>.tab1", "target": "<default>.vw1"}}]}\n'  # noqa: E501
+    stdout, stderror = capfd.readouterr()  # Capture stdout, stderror
+    # Test that the lineage output we have is the lineage we want
+    assert sorted_json(json.loads(str(stdout))) == sorted_json(json.loads(want))
+
+
+def test_nonjson_cli_column_output(capfd):
+    """
+    Test that column-level normal CLI lineage output is as expected.
+    """
+    main(
+        ["--level=column", "-e", "CREATE VIEW vw1 AS SELECT col1 FROM tab1"]
+    )  # Run a trivial lineage
+    # The output we want
+    want = "<default>.vw1.col1 <- <default>.tab1.col1\n"
+    stdout, stderror = capfd.readouterr()  # Capture stdout, stderror
+    # Test that the lineage output we have is the lineage we want
+    assert stdout == want
+
+
+def test_json_cli_column_output(capfd):
+    """
+    Test that column-level JSON CLI lineage output is as expected.
+    """
+    main(
+        ["--level=column", "--json", "-e", "CREATE VIEW vw1 AS SELECT col1 FROM tab1"]
+    )  # Run a trivial lineage
+    # The output we want - yes we want a singleline string output this long
+    want = '{"column": [{"data": {"id": "<default>.tab1.col1", "parent": "<default>.tab1", "parent_candidates": [{"name": "<default>.tab1", "type": "Table"}], "type": "Column"}}, {"data": {"id": "<default>.vw1.col1", "parent": "<default>.vw1", "parent_candidates": [{"name": "<default>.vw1", "type": "Table"}], "type": "Column"}}, {"data": {"id": "<default>.tab1", "type": "Table"}}, {"data": {"id": "<default>.vw1", "type": "Table"}}, {"data": {"id": "e0", "source": "<default>.tab1.col1", "target": "<default>.vw1.col1"}}], "dag": [{"data": {"id": "<default>.vw1"}}, {"data": {"id": "<default>.tab1"}}, {"data": {"id": "e0", "source": "<default>.tab1", "target": "<default>.vw1"}}]}\n'  # noqa: E501
+    stdout, stderror = capfd.readouterr()  # Capture stdout, stderror
+    # Test that the lineage output we have is the lineage we want
+    assert sorted_json(json.loads(str(stdout))) == sorted_json(json.loads(want))

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sqllineage.runner import LineageRunner
+from sqllineage.utils.constant import LineageLevel
 from sqllineage.utils.entities import ColumnQualifierTuple
 from .helpers import assert_column_lineage_equal
 
@@ -711,7 +712,7 @@ SELECT col1,
        col3
 FROM tab2"""
     # just assure no exception, don't guarantee the result
-    LineageRunner(sql).print_column_lineage()
+    LineageRunner(sql).print_lineage(lineage_level=LineageLevel.COLUMN, json_out=False)
 
 
 def test_column_reference_from_cte_using_alias():


### PR DESCRIPTION
Adds feature #298 by using the existing `to_cytoscape()` function to write out compact machine-readable json on stdout.