### PR TITLE
fix: unnest function call with extra space in between

### DIFF
--- a/sqllineage/core/handlers/base.py
+++ b/sqllineage/core/handlers/base.py
@@ -27,9 +27,7 @@ class NextTokenBaseHandler:
         """
         Set indicator to True only when _indicate returns True
         """
-        indicator = self._indicate(token)
-        if indicator:
-            self.indicator = True
+        self.indicator = self._indicate(token)
 
     def handle(self, token: Token, holder: SubQueryLineageHolder):
         """

--- a/sqllineage/core/handlers/cte.py
+++ b/sqllineage/core/handlers/cte.py
@@ -1,9 +1,8 @@
-from sqlparse.sql import Function, Identifier, IdentifierList, Parenthesis, Token
+from sqlparse.sql import Function, Identifier, IdentifierList, Token
 
 from sqllineage.core.handlers.base import NextTokenBaseHandler
 from sqllineage.core.holders import SubQueryLineageHolder
 from sqllineage.core.models import SubQuery
-from sqllineage.exceptions import SQLLineageException
 
 
 class CTEHandler(NextTokenBaseHandler):
@@ -23,15 +22,10 @@ class CTEHandler(NextTokenBaseHandler):
             cte = [
                 token for token in token.tokens if isinstance(token, cte_token_types)
             ]
-        elif isinstance(token, Parenthesis):
-            # CREATE TABLE tbl1 (col1 VARCHAR) WITH (bucketed_by = ARRAY['col1'], bucket_count = 256).
-            # This syntax is valid for bucketing in Trino and not the CTE
-            cte = []
         else:
-            raise SQLLineageException(
-                "An Identifier or IdentifierList is expected, got %s[value: %s] instead."
-                % (type(token).__name__, token)
-            )
+            # CREATE TABLE tbl1 (col1 VARCHAR) WITH (bucketed_by = ARRAY['col1'], bucket_count = 256).
+            # This syntax is valid for bucketing in Trino and not the CTE, token will be Parenthesis here
+            cte = []
         for token in cte:
             sublist = list(token.get_sublists())
             if sublist:

--- a/sqllineage/core/handlers/target.py
+++ b/sqllineage/core/handlers/target.py
@@ -10,10 +10,26 @@ from sqllineage.exceptions import SQLLineageException
 class TargetHandler(NextTokenBaseHandler):
     """Target Table Handler."""
 
-    TARGET_TABLE_TOKENS = ("INTO", "OVERWRITE", "TABLE", "VIEW", "UPDATE", "COPY")
+    TARGET_TABLE_TOKENS = (
+        "INTO",
+        "OVERWRITE",
+        "TABLE",
+        "VIEW",
+        "UPDATE",
+        "COPY",
+        "DIRECTORY",
+    )
 
     def _indicate(self, token: Token) -> bool:
-        return token.normalized in self.TARGET_TABLE_TOKENS
+        if (
+            self.indicator is True
+            and token.is_keyword
+            and token.normalized in ("IF", "NOT", "EXISTS")
+        ):
+            # special handling for CREATE TABLE IF NOT EXISTS
+            return True
+        else:
+            return token.normalized in self.TARGET_TABLE_TOKENS
 
     def _handle(self, token: Token, holder: SubQueryLineageHolder) -> None:
         if isinstance(token, Function):
@@ -40,12 +56,7 @@ class TargetHandler(NextTokenBaseHandler):
             holder.add_read(Table.of(token.right))
         elif token.ttype == Literal.String.Single:
             holder.add_write(Path(token.value))
-        else:
-            if not isinstance(token, Identifier):
-                raise SQLLineageException(
-                    "An Identifier is expected, got %s[value: %s] instead."
-                    % (type(token).__name__, token)
-                )
+        elif isinstance(token, Identifier):
             if token.token_first(skip_cm=True).ttype is Number.Integer:
                 # Special Handling for Spark Bucket Table DDL
                 pass

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -7,15 +7,3 @@ from sqllineage.runner import LineageRunner
 def test_select_without_table():
     with pytest.raises(SQLLineageException):
         LineageRunner("select * from where foo='bar'")._eval()
-
-
-def test_insert_without_table():
-    with pytest.raises(SQLLineageException):
-        LineageRunner("insert into select * from foo")._eval()
-
-
-def test_with_cte_without_table():
-    with pytest.raises(SQLLineageException):
-        LineageRunner(
-            "with as select * from foo insert into table bar select * from foo"
-        )._eval()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -234,6 +234,14 @@ def test_select_from_unnest():
     )
 
 
+def test_select_from_unnest_parsed_as_keyword():
+    # an extra space after UNNEST changes the AST structure
+    assert_table_lineage_equal(
+        "SELECT student, score FROM tests CROSS JOIN UNNEST (scores) AS t (score)",
+        {"tests"},
+    )
+
+
 def test_select_from_unnest_with_ordinality():
     sql = """SELECT numbers, n, a
 FROM (


### PR DESCRIPTION
Solving the new edge cases mentioned in #301 