### PR TITLE
test: non-reserved keyword as identifier name

### DIFF
--- a/tests/test_sqlfluff.py
+++ b/tests/test_sqlfluff.py
@@ -61,3 +61,44 @@ def test_insert_into_qualified_table_with_parenthesized_query():
     (SELECT *
     FROM tab1)"""
     assert_table_lineage_equal(sql, {"tab1"}, {"default.tab2"}, test_sqlparse=False)
+
+
+# sqlparse doesn't handle keyword as identifier name very well for following cases
+def test_non_reserved_keyword_as_source():
+    assert_table_lineage_equal(
+        "SELECT col1, col2 FROM segment", {"segment"}, test_sqlparse=False
+    )
+
+
+def test_non_reserved_keyword_as_target():
+    assert_table_lineage_equal(
+        "INSERT INTO host SELECT col1, col2 FROM segment",
+        {"segment"},
+        {"host"},
+        test_sqlparse=False,
+    )
+
+
+def test_non_reserved_keyword_as_cte():
+    assert_table_lineage_equal(
+        "WITH summary AS (SELECT * FROM segment) INSERT INTO host SELECT * FROM summary",
+        {"segment"},
+        {"host"},
+        test_sqlparse=False,
+    )
+
+
+def test_non_reserved_keyword_as_column_name():
+    sql = """INSERT INTO tab1
+SELECT CASE WHEN locate('.', a.col1) > 0 THEN substring_index(a.col1, '.', 3) END host
+FROM tab2 a"""
+    assert_column_lineage_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("host", "tab1"),
+            )
+        ],
+        test_sqlparse=False,
+    )


### PR DESCRIPTION
Closes #93 