### PR TITLE
Fix version of 'sqlparse' dependency to 0.4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "sqlparse>=0.3.1",
+        "sqlparse==0.4.3",
         "networkx>=2.4",
         "sqlfluff>=1.4.5",
     ],

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,9 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "sqlparse==0.4.4",
+        "sqlparse>=0.4.4",
         "networkx>=2.4",
-        "sqlfluff==2.0.3",
+        "sqlfluff>=2.0.0,<=2.0.3",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,9 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "sqlparse==0.4.3",
+        "sqlparse==0.4.4",
         "networkx>=2.4",
-        "sqlfluff>=1.4.5",
+        "sqlfluff==2.0.3",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},
     extras_require={

--- a/sqllineage/core/parser/sqlparse/__init__.py
+++ b/sqllineage/core/parser/sqlparse/__init__.py
@@ -18,10 +18,10 @@ def _patch_adding_builtin_type() -> None:
 
 def _patch_updating_lateral_view_lexeme() -> None:
     for i, (regex, lexeme) in enumerate(SQL_REGEX):
-        if regex("LATERAL VIEW EXPLODE(col)"):
+        rgx = re.compile(regex, re.IGNORECASE | re.UNICODE).match
+        if rgx("LATERAL VIEW EXPLODE(col)"):
             new_regex = r"(LATERAL\s+VIEW\s+)(OUTER\s+)?(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK|JSON_TUPLE)\b"
-            new_compile = re.compile(new_regex, re.IGNORECASE | re.UNICODE).match
-            SQL_REGEX[i] = (new_compile, lexeme)
+            SQL_REGEX[i] = (new_regex, lexeme)
             break
 
 

--- a/sqllineage/core/parser/sqlparse/models.py
+++ b/sqllineage/core/parser/sqlparse/models.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from sqlparse import tokens as T
 from sqlparse.engine import grouping
-from sqlparse.keywords import is_keyword
 from sqlparse.sql import (
     Case,
     Comparison,
@@ -15,6 +14,7 @@ from sqlparse.sql import (
     TokenList,
 )
 from sqlparse.utils import imt
+from sqlparse.lexer import Lexer
 
 from sqllineage.core.models import Column, Schema, SubQuery, Table
 from sqllineage.core.parser.sqlparse.utils import get_parameters, is_subquery
@@ -158,7 +158,11 @@ class SqlParseColumn(Column):
                 isinstance(t, Function) and t.get_real_name() not in FUNC_DTYPE
                 for t in token.tokens
             )
-            is_kw = is_keyword(real_name) if real_name is not None else False
+            is_kw = (
+                Lexer.get_default_instance().is_keyword(real_name)
+                if real_name is not None
+                else False
+            )
             if (
                 # real name is None: col1=1 AS int
                 real_name is None

--- a/sqllineage/core/parser/sqlparse/models.py
+++ b/sqllineage/core/parser/sqlparse/models.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from sqlparse import tokens as T
 from sqlparse.engine import grouping
+from sqlparse.lexer import Lexer
 from sqlparse.sql import (
     Case,
     Comparison,
@@ -14,7 +15,6 @@ from sqlparse.sql import (
     TokenList,
 )
 from sqlparse.utils import imt
-from sqlparse.lexer import Lexer
 
 from sqllineage.core.models import Column, Schema, SubQuery, Table
 from sqllineage.core.parser.sqlparse.utils import get_parameters, is_subquery


### PR DESCRIPTION
With the latest `0.4.4` version of `sqlparse`, we started to see this error when doing the _monkey_patch() to the library:

```
env/lib/python3.9/site-packages/sqllineage/runner.py:9: in <module>
    from sqllineage.core.parser.sqlparse.analyzer import SqlParseLineageAnalyzer
env/lib/python3.9/site-packages/sqllineage/core/parser/sqlparse/__init__.py:34: in <module>
    _monkey_patch()
env/lib/python3.9/site-packages/sqllineage/core/parser/sqlparse/__init__.py:31: in _monkey_patch
    _patch_updating_lateral_view_lexeme()
env/lib/python3.9/site-packages/sqllineage/core/parser/sqlparse/__init__.py:21: in _patch_updating_lateral_view_lexeme
    if regex("LATERAL VIEW EXPLODE(col)"):
E   TypeError: 'str' object is not callable
```