### PR TITLE
support create table..clone and alter table...swap

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/ddl_alter_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/ddl_alter_extractor.py
@@ -13,6 +13,8 @@ class DdlAlterExtractor(LineageHolderExtractor):
     DDL Alter queries lineage extractor
     """
 
+    SOURCE_KEYWORDS = {"EXCHANGE", "SWAP"}
+
     SUPPORTED_STMT_TYPES = [
         "alter_table_statement",
         "rename_statement",
@@ -44,7 +46,10 @@ class DdlAlterExtractor(LineageHolderExtractor):
         if any(k.raw_upper == "RENAME" for k in keywords):
             if statement.type == "alter_table_statement" and len(tables) == 2:
                 holder.add_rename(tables[0], tables[1])
-        if any(k.raw_upper == "EXCHANGE" for k in keywords) and len(tables) == 2:
+        if (
+            any(k.raw_upper in self.SOURCE_KEYWORDS for k in keywords)
+            and len(tables) == 2
+        ):
             holder.add_write(tables[0])
             holder.add_read(tables[1])
         return holder

--- a/sqllineage/core/parser/sqlfluff/handlers/target.py
+++ b/sqllineage/core/parser/sqlfluff/handlers/target.py
@@ -52,7 +52,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
 
     def _reset_tokens(self) -> None:
         """
-        Set 'prev_token_like' and 'prev_token_like' variable to False
+        Set 'prev_token_from' and 'prev_token_read' variable to False
         """
         self.prev_token_read = False
         self.prev_token_from = False

--- a/sqllineage/core/parser/sqlfluff/handlers/target.py
+++ b/sqllineage/core/parser/sqlfluff/handlers/target.py
@@ -22,7 +22,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
 
     def __init__(self) -> None:
         self.indicator = False
-        self.prev_token_like = False
+        self.prev_token_read = False
         self.prev_token_from = False
 
     TARGET_KEYWORDS = (
@@ -35,7 +35,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
         "DIRECTORY",
     )
 
-    LIKE_KEYWORD = "LIKE"
+    READ_KEYWORDS = {"LIKE", "CLONE"}
 
     FROM_KEYWORD = "FROM"
 
@@ -44,8 +44,8 @@ class TargetHandler(ConditionalSegmentBaseHandler):
         Check if the segment is a 'LIKE' or 'FROM' keyword
         :param segment: segment to be use for checking
         """
-        if segment.raw_upper == self.LIKE_KEYWORD:
-            self.prev_token_like = True
+        if segment.raw_upper in self.READ_KEYWORDS:
+            self.prev_token_read = True
 
         if segment.raw_upper == self.FROM_KEYWORD:
             self.prev_token_from = True
@@ -54,7 +54,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
         """
         Set 'prev_token_like' and 'prev_token_like' variable to False
         """
-        self.prev_token_like = False
+        self.prev_token_read = False
         self.prev_token_from = False
 
     def indicate(self, segment: BaseSegment) -> bool:
@@ -81,7 +81,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
         """
         if segment.type == "table_reference":
             write_obj = SqlFluffTable.of(segment)
-            if self.prev_token_like:
+            if self.prev_token_read:
                 holder.add_read(write_obj)
             else:
                 holder.add_write(write_obj)

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -105,6 +105,17 @@ def test_create_clone(dialect: str):
     )
 
 
+@pytest.mark.parametrize("dialect", ["bigquery"])
+def test_bigquery_create_clone(dialect: str):
+    assert_table_lineage_equal(
+        "CREATE TABLE myproject.myDataset_backup.myTableClone CLONE myproject.myDataset.myTable;",
+        {"myproject.myDataset.myTable"},
+        {"myproject.myDataset_backup.myTableClone"},
+        dialect=dialect,
+        test_sqlparse=False,
+    )
+
+
 @pytest.mark.parametrize("dialect", ["snowflake"])
 def test_alter_table_swap_partition(dialect: str):
     """

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -96,18 +96,16 @@ def test_alter_table_exchange_partition(dialect: str):
 
 @pytest.mark.parametrize("dialect", ["snowflake", "bigquery"])
 def test_create_clone(dialect: str):
+    """
+    Language manual:
+        https://cloud.google.com/bigquery/docs/table-clones-create
+        https://docs.snowflake.com/en/sql-reference/sql/create-clone
+    Note clone is not a keyword in sqlparse, we'll skip testing for it.
+    """
     assert_table_lineage_equal(
         "create table tab2 CLONE tab1;",
         {"tab1"},
         {"tab2"},
-        dialect=dialect,
-        test_sqlparse=False,
-    )
-
-    assert_table_lineage_equal(
-        "CREATE TABLE myproject.myDataset_backup.myTableClone CLONE myproject.myDataset.myTable;",
-        {"myproject.myDataset.myTable"},
-        {"myproject.myDataset_backup.myTableClone"},
         dialect=dialect,
         test_sqlparse=False,
     )
@@ -117,6 +115,7 @@ def test_create_clone(dialect: str):
 def test_alter_table_swap_partition(dialect: str):
     """
     See https://docs.snowflake.com/en/sql-reference/sql/alter-table for language manual
+    Note swap is not a keyword in sqlparse, we'll skip testing for it.
     """
     assert_table_lineage_equal(
         "alter table tab1 swap with tab2",

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -94,7 +94,7 @@ def test_alter_table_exchange_partition(dialect: str):
     )
 
 
-@pytest.mark.parametrize("dialect", ["snowflake"])
+@pytest.mark.parametrize("dialect", ["snowflake","bigquery"])
 def test_create_clone(dialect: str):
     assert_table_lineage_equal(
         "create table tab2 CLONE tab1;",
@@ -103,18 +103,6 @@ def test_create_clone(dialect: str):
         dialect=dialect,
         test_sqlparse=False,
     )
-
-
-@pytest.mark.parametrize("dialect", ["bigquery"])
-def test_bigquery_create_clone(dialect: str):
-    assert_table_lineage_equal(
-        "CREATE TABLE myproject.myDataset_backup.myTableClone CLONE myproject.myDataset.myTable;",
-        {"myproject.myDataset.myTable"},
-        {"myproject.myDataset_backup.myTableClone"},
-        dialect=dialect,
-        test_sqlparse=False,
-    )
-
 
 @pytest.mark.parametrize("dialect", ["snowflake"])
 def test_alter_table_swap_partition(dialect: str):

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -94,6 +94,31 @@ def test_alter_table_exchange_partition(dialect: str):
     )
 
 
+@pytest.mark.parametrize("dialect", ["snowflake"])
+def test_create_clone(dialect: str):
+    assert_table_lineage_equal(
+        "create table tab2 CLONE tab1;",
+        {"tab1"},
+        {"tab2"},
+        dialect=dialect,
+        test_sqlparse=False,
+    )
+
+
+@pytest.mark.parametrize("dialect", ["snowflake"])
+def test_alter_table_exchange_partition(dialect: str):
+    """
+    See https://docs.snowflake.com/en/sql-reference/sql/alter-table for language manual
+    """
+    assert_table_lineage_equal(
+        "alter table tab1 swap with tab2",
+        {"tab2"},
+        {"tab1"},
+        dialect=dialect,
+        test_sqlparse=False,
+    )
+
+
 @pytest.mark.parametrize("dialect", ["databricks", "sparksql"])
 def test_refresh_table(dialect: str):
     assert_table_lineage_equal("refresh table tab1", None, None, dialect)

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -106,7 +106,7 @@ def test_create_clone(dialect: str):
 
 
 @pytest.mark.parametrize("dialect", ["snowflake"])
-def test_alter_table_exchange_partition(dialect: str):
+def test_alter_table_swap_partition(dialect: str):
     """
     See https://docs.snowflake.com/en/sql-reference/sql/alter-table for language manual
     """

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -94,7 +94,7 @@ def test_alter_table_exchange_partition(dialect: str):
     )
 
 
-@pytest.mark.parametrize("dialect", ["snowflake","bigquery"])
+@pytest.mark.parametrize("dialect", ["snowflake", "bigquery"])
 def test_create_clone(dialect: str):
     assert_table_lineage_equal(
         "create table tab2 CLONE tab1;",

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -104,6 +104,15 @@ def test_create_clone(dialect: str):
         test_sqlparse=False,
     )
 
+    assert_table_lineage_equal(
+        "CREATE TABLE myproject.myDataset_backup.myTableClone CLONE myproject.myDataset.myTable;",
+        {"myproject.myDataset.myTable"},
+        {"myproject.myDataset_backup.myTableClone"},
+        dialect=dialect,
+        test_sqlparse=False,
+    )
+
+
 @pytest.mark.parametrize("dialect", ["snowflake"])
 def test_alter_table_swap_partition(dialect: str):
     """


### PR DESCRIPTION
`create table tab2 CLONE tab1` and `alter table tab1 swap with tab2` types of queries are not supported adding the support for the same with this pr


part of fix for https://github.com/open-metadata/OpenMetadata/issues/9389


---
Closes #373 