### PR TITLE
Fix merge queries

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
@@ -4,10 +4,10 @@ from sqlfluff.core.parser import BaseSegment
 
 from sqllineage.core.holders import StatementLineageHolder, SubQueryLineageHolder
 from sqllineage.core.models import AnalyzerContext, Column, SubQuery, Table
+from sqllineage.core.parser.sqlfluff.extractors.cte_extractor import DmlCteExtractor
 from sqllineage.core.parser.sqlfluff.extractors.dml_select_extractor import (
     DmlSelectExtractor,
 )
-from sqllineage.core.parser.sqlfluff.extractors.cte_extractor import DmlCteExtractor
 from sqllineage.core.parser.sqlfluff.extractors.lineage_holder_extractor import (
     LineageHolderExtractor,
 )

--- a/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
@@ -7,6 +7,7 @@ from sqllineage.core.models import AnalyzerContext, Column, SubQuery, Table
 from sqllineage.core.parser.sqlfluff.extractors.dml_select_extractor import (
     DmlSelectExtractor,
 )
+from sqllineage.core.parser.sqlfluff.extractors.cte_extractor import DmlCteExtractor
 from sqllineage.core.parser.sqlfluff.extractors.lineage_holder_extractor import (
     LineageHolderExtractor,
 )
@@ -40,7 +41,7 @@ class DmlMergeExtractor(LineageHolderExtractor):
         direct_source: Optional[Union[Table, SubQuery]] = None
         segments = retrieve_segments(statement)
         for i, segment in enumerate(segments):
-            if segment.type == "keyword" and segment.raw_upper == "INTO":
+            if segment.type == "keyword" and segment.raw_upper in {"INTO", "MERGE"}:
                 tgt_flag = True
                 continue
             if segment.type == "keyword" and segment.raw_upper == "USING":
@@ -64,9 +65,18 @@ class DmlMergeExtractor(LineageHolderExtractor):
                         else None,
                     )
                     holder.add_read(direct_source)
-                    holder |= DmlSelectExtractor(self.dialect).extract(
-                        direct_source.query, AnalyzerContext(direct_source, holder.cte)
-                    )
+                    if direct_source.query.get_child("with_compound_statement"):
+                        # in case the subquery is a CTE query
+                        holder |= DmlCteExtractor(self.dialect).extract(
+                            direct_source.query,
+                            AnalyzerContext(direct_source, prev_cte=holder.cte),
+                        )
+                    else:
+                        # in case the subquery is a select query
+                        holder |= DmlSelectExtractor(self.dialect).extract(
+                            direct_source.query,
+                            AnalyzerContext(direct_source, holder.cte),
+                        )
                 src_flag = False
 
         for match in get_grandchildren(
@@ -90,19 +100,23 @@ class DmlMergeExtractor(LineageHolderExtractor):
         ):
             merge_insert = not_match.get_child("merge_insert_clause")
             insert_columns = []
-            for c in merge_insert.get_child("bracketed").get_children(
+            merge_insert_bracketed = merge_insert.get_child("bracketed")
+            if merge_insert_bracketed and merge_insert_bracketed.get_children(
                 "column_reference"
             ):
-                tgt_col = Column(get_identifier(c))
-                tgt_col.parent = list(holder.write)[0]
-                insert_columns.append(tgt_col)
-            for j, e in enumerate(
-                merge_insert.get_child("values_clause")
-                .get_child("bracketed")
-                .get_children("expression")
-            ):
-                if col_ref := e.get_child("column_reference"):
-                    src_col = Column(get_identifier(col_ref))
-                    src_col.parent = direct_source
-                    holder.add_column_lineage(src_col, insert_columns[j])
+                for c in merge_insert.get_child("bracketed").get_children(
+                    "column_reference"
+                ):
+                    tgt_col = Column(get_identifier(c))
+                    tgt_col.parent = list(holder.write)[0]
+                    insert_columns.append(tgt_col)
+                for j, e in enumerate(
+                    merge_insert.get_child("values_clause")
+                    .get_child("bracketed")
+                    .get_children("expression")
+                ):
+                    if col_ref := e.get_child("column_reference"):
+                        src_col = Column(get_identifier(col_ref))
+                        src_col.parent = direct_source
+                        holder.add_column_lineage(src_col, insert_columns[j])
         return holder

--- a/sqllineage/core/parser/sqlparse/analyzer.py
+++ b/sqllineage/core/parser/sqlparse/analyzer.py
@@ -107,7 +107,7 @@ class SqlParseLineageAnalyzer(LineageAnalyzer):
             if is_token_negligible(token):
                 continue
             if token.is_keyword:
-                if token.normalized == "INTO":
+                if token.normalized in {"INTO", "MERGE"}:
                     tgt_flag = True
                 elif token.normalized == "USING":
                     src_flag = True
@@ -160,7 +160,7 @@ class SqlParseLineageAnalyzer(LineageAnalyzer):
                         tgt_col = Column(identifier.get_real_name())
                         tgt_col.parent = list(holder.write)[0]
                         insert_columns.append(tgt_col)
-                elif isinstance(token, Values):
+                elif insert_columns and isinstance(token, Values):
                     for sub_token in token.tokens:
                         if isinstance(sub_token, Parenthesis):
                             t = sub_token.tokens[1]

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -238,3 +238,10 @@ def test_merge_using_cte_subquery():
         {"dataset_id.target_table"},
         test_sqlparse=False,
     )
+
+
+def test_merge_into_insert_one_column():
+    sql = """MERGE INTO target
+    USING src ON target.k = src.k
+    WHEN NOT MATCHED THEN INSERT VALUES (src.k)"""
+    assert_table_lineage_equal(sql, {"src"}, {"target"})

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -137,3 +137,48 @@ LATERAL VIEW OUTER explode(sc.json_array) q AS col1"""
 @pytest.mark.parametrize("dialect", ["databricks", "sparksql"])
 def test_show_create_table(dialect: str):
     assert_table_lineage_equal("show create table tab1", None, None, dialect)
+
+
+@pytest.mark.parametrize("dialect", ["bigquery"])
+def test_merge_into_insert_one_column(dialect: str):
+    sql = """MERGE INTO target
+USING src ON target.k = src.k
+WHEN NOT MATCHED THEN INSERT VALUES (src.k)"""
+    assert_table_lineage_equal(sql, {"src"}, {"target"}, dialect=dialect)
+
+
+@pytest.mark.parametrize("dialect", ["bigquery"])
+def test_merge_using_subquery(dialect: str):
+    sql = """MERGE target USING (select k, max(v) as v from src group by k) AS b ON target.k = b.k
+WHEN MATCHED THEN UPDATE SET target.v = b.v
+WHEN NOT MATCHED THEN INSERT (k, v) VALUES (b.k, b.v)"""
+    assert_table_lineage_equal(sql, {"src"}, {"target"}, dialect=dialect)
+
+
+@pytest.mark.parametrize("dialect", ["bigquery"])
+def test_merge_using_cte_subquery(dialect: str):
+    sql = """MERGE `project_id.dataset_id.target_table` t
+    USING (
+    WITH base AS (
+        SELECT
+            date, channel, cnt, user_count, total_user_count,
+        FROM `project_id.dataset_id.origin_table`
+    )
+    SELECT
+        date, channel, cnt, total_user_count, SAFE_DIVIDE(cnt, user_count) AS rate
+    FROM base
+    ) s
+    ON t.date = s.date and t.channel = s.channel
+    WHEN NOT MATCHED THEN
+    INSERT ROW
+    WHEN MATCHED THEN
+    UPDATE SET t.total_user_cnt = s.total_user_cnt,
+    t.cnt = s.cnt,
+    t.rate = s.rat"""
+    assert_table_lineage_equal(
+        sql,
+        {"project_id.dataset_id.origin_table"},
+        {"project_id.dataset_id.target_table"},
+        dialect=dialect,
+        test_sqlparse=False,
+    )

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -140,14 +140,6 @@ def test_show_create_table(dialect: str):
 
 
 @pytest.mark.parametrize("dialect", ["bigquery"])
-def test_merge_into_insert_one_column(dialect: str):
-    sql = """MERGE INTO target
-USING src ON target.k = src.k
-WHEN NOT MATCHED THEN INSERT VALUES (src.k)"""
-    assert_table_lineage_equal(sql, {"src"}, {"target"}, dialect=dialect)
-
-
-@pytest.mark.parametrize("dialect", ["bigquery"])
 def test_merge_using_subquery(dialect: str):
     sql = """MERGE target USING (select k, max(v) as v from src group by k) AS b ON target.k = b.k
 WHEN MATCHED THEN UPDATE SET target.v = b.v


### PR DESCRIPTION
In case merge queries for bigquery following are the cases that needs to be handled:

* The `INTO` keyword after `MERGE` is optional 
* The column references after `INSERT` are optional for example `INSERT VALUES (actual...values)`
* The subquery after `USING` keyword can be a CTE query (this is not specific to bigquery)

part of fix for https://github.com/open-metadata/OpenMetadata/issues/7427 [ref1](https://github.com/open-metadata/OpenMetadata/issues/7427#issuecomment-1385057852) [ref2](https://github.com/open-metadata/OpenMetadata/issues/7427#issuecomment-1371901135)


Closes #380 