### PR TITLE
Handle optional parent for col lineage

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/dml_insert_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/dml_insert_extractor.py
@@ -22,6 +22,7 @@ class DmlInsertExtractor(LineageHolderExtractor):
     SUPPORTED_STMT_TYPES = [
         "insert_statement",
         "create_table_statement",
+        "create_table_as_statement",
         "create_view_statement",
         "update_statement",
         "copy_statement",

--- a/sqllineage/core/parser/sqlfluff/handlers/target.py
+++ b/sqllineage/core/parser/sqlfluff/handlers/target.py
@@ -80,7 +80,7 @@ class TargetHandler(ConditionalSegmentBaseHandler):
         :param segment: segment to be handled
         :param holder: 'SqlFluffSubQueryLineageHolder' to hold lineage
         """
-        if segment.type == "table_reference":
+        if segment.type in ["table_reference", "object_reference"]:
             write_obj = SqlFluffTable.of(segment)
             if self.prev_token_read:
                 holder.add_read(write_obj)

--- a/sqllineage/core/parser/sqlfluff/models.py
+++ b/sqllineage/core/parser/sqlfluff/models.py
@@ -192,7 +192,9 @@ class SqlFluffColumn(Column):
             ).get_column_lineage(exclude_subquery=False)
         ]
         source_columns = [
-            ColumnQualifierTuple(src_col.raw_name, src_col.parent.raw_name)
+            ColumnQualifierTuple(
+                src_col.raw_name, src_col.parent.raw_name if src_col.parent else None
+            )
             for src_col in src_cols
         ]
         return source_columns

--- a/sqllineage/core/parser/sqlparse/models.py
+++ b/sqllineage/core/parser/sqlparse/models.py
@@ -116,7 +116,10 @@ class SqlParseColumn(Column):
                     )
                 ]
                 source_columns = [
-                    ColumnQualifierTuple(src_col.raw_name, src_col.parent.raw_name)
+                    ColumnQualifierTuple(
+                        src_col.raw_name,
+                        src_col.parent.raw_name if src_col.parent else None,
+                    )
                     for src_col in src_cols
                 ]
             else:

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -24,6 +24,22 @@ def test_create_select_without_as(dialect: str):
     )
 
 
+@pytest.mark.parametrize("dialect", ["duckdb", "greenplum", "postgres", "redshift"])
+def test_create_table_as_with_postgres_dialect(dialect: str):
+    """
+    sqlfluff postgres family dialects parse CTAS statement as "create_table_as_statement",
+    unlike "create_table_statement" in ansi dialect
+    """
+    assert_table_lineage_equal(
+        """CREATE TABLE bar AS
+SELECT *
+FROM foo""",
+        {"foo"},
+        {"bar"},
+        dialect,
+    )
+
+
 def test_create_using_serde():
     """
     https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RowFormats&SerDe

--- a/tests/test_sqlfluff.py
+++ b/tests/test_sqlfluff.py
@@ -278,3 +278,23 @@ def test_insert_with_custom_columns():
         ],
         test_sqlparse=False,
     )
+
+
+@pytest.mark.parametrize("dialect", ["postgres"])
+def test_create_table_with_cte(dialect: str):
+    assert_table_lineage_equal(
+        """create table my_new_table as
+        WITH my_data AS (
+            SELECT
+                column1,
+                column2,
+                (select column1 + column2 as result) as sum_result
+            FROM my_table
+        )
+        SELECT *
+        FROM my_data""",
+        {"<default>.my_table"},
+        {"<default>.my_new_table"},
+        dialect,
+        test_sqlparse=False,
+    )


### PR DESCRIPTION
Handle where parent is not available, also add support for `create_table_as_statement` which is specific to postgres dialect for sqlfluff


fix for https://github.com/open-metadata/OpenMetadata/issues/9011

---
Closes #400 
Closes #401 