### PR TITLE
Fix issue #398: add parse union at the end of cte

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/cte_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/cte_extractor.py
@@ -49,7 +49,7 @@ class DmlCteExtractor(LineageHolderExtractor):
             for current_handler in handlers:
                 current_handler.handle(segment, holder)
 
-            if segment.type == "select_statement":
+            if segment.type in ["select_statement", "set_expression"]:
                 holder |= DmlSelectExtractor(self.dialect).extract(
                     segment,
                     AnalyzerContext(prev_cte=holder.cte, prev_write=holder.write),

--- a/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
@@ -41,7 +41,10 @@ class DmlMergeExtractor(LineageHolderExtractor):
         direct_source: Optional[Union[Table, SubQuery]] = None
         segments = retrieve_segments(statement)
         for i, segment in enumerate(segments):
-            if segment.type == "keyword" and segment.raw_upper in {"INTO", "MERGE"}:
+            if segment.type == "keyword" and segment.raw_upper == "MERGE":
+                tgt_flag = True
+                continue
+            if segment.type == "keyword" and segment.raw_upper == "INTO":
                 tgt_flag = True
                 continue
             if segment.type == "keyword" and segment.raw_upper == "USING":

--- a/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/dml_merge_extractor.py
@@ -41,10 +41,7 @@ class DmlMergeExtractor(LineageHolderExtractor):
         direct_source: Optional[Union[Table, SubQuery]] = None
         segments = retrieve_segments(statement)
         for i, segment in enumerate(segments):
-            if segment.type == "keyword" and segment.raw_upper == "MERGE":
-                tgt_flag = True
-                continue
-            if segment.type == "keyword" and segment.raw_upper == "INTO":
+            if segment.type == "keyword" and segment.raw_upper in {"INTO", "MERGE"}:
                 tgt_flag = True
                 continue
             if segment.type == "keyword" and segment.raw_upper == "USING":

--- a/tests/test_others_dialect_specific.py
+++ b/tests/test_others_dialect_specific.py
@@ -202,3 +202,30 @@ UPDATE SET t.col = s.col"""
         {"tgt"},
         dialect=dialect,
     )
+
+
+@pytest.mark.parametrize("dialect", ["ansi"])
+def test_union_in_insert_with_cte(dialect: str):
+    # issue #398
+    sql = """INSERT INTO target_table
+WITH pl AS (
+  SELECT id, school
+FROM table1)
+, fb AS (
+SELECT id, school
+FROM table2)
+SELECT
+table3.id, table3.name, table1.school
+FROM table3
+LEFT JOIN table1 ON table3.id = table1.id
+UNION
+SELECT
+table4.id, table4.name, table2.school
+FROM table4
+LEFT JOIN table2 ON table4.id = table2.id"""
+    assert_table_lineage_equal(
+        sql,
+        {"table1", "table2", "table3", "table4"},
+        {"target_table"},
+        dialect=dialect,
+    )


### PR DESCRIPTION
Fix issue #398
add test with specific dialect (ansi), work well with Bigquery if we use "UNION ALL" rather than "UNION".