### PR TITLE
feat: store original source expression for columns

### DIFF
--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -304,6 +304,7 @@ class SQLLineageHolder(ColumnLineageMixin):
             for parent in unresolved_col.parent_candidates:
                 src_col = Column(unresolved_col.raw_name)
                 src_col.parent = parent
+                src_col.source_expression = unresolved_col.source_expression
                 if g.has_edge(parent, src_col):
                     src_cols.append(src_col)
             if len(src_cols) == 1:

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -1,4 +1,3 @@
-import copy
 import itertools
 from typing import Dict, List, Set, Tuple, Union
 
@@ -269,7 +268,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         :class:`sqllineage.holders.SQLLineageHolder`
         """
         g = DiGraph()
-        column_expressions = {}
+        column_expressions: Dict[Tuple[Column, ...], List[str]] = {}
         for holder in args:
             # Storing column expressions
             column_lineage = holder.get_column_lineage(False)

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -273,8 +273,10 @@ class SQLLineageHolder(ColumnLineageMixin):
             # Storing column expressions
             column_lineage = holder.get_column_lineage(False)
             for item in column_lineage:
-                item_expressions = column_expressions.setdefault(item, [])
-                item_expressions.append(item[0]._source_expression)
+                for i in range(len(item) - 1):
+                    pair = (item[i], item[i + 1])
+                    pair_expressions = column_expressions.setdefault(pair, [])
+                    pair_expressions.append(pair[0]._source_expression)
 
             g = nx.compose(g, holder.graph)
             if holder.drop:

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -35,11 +35,12 @@ class ColumnLineageMixin:
                 columns.add(tuple(path))
         return columns
 
-    def get_column_lineage_edges(self, exclude_subquery=True) -> Set[Tuple[Column, Column, str]]:
-        column_edges = [(edge[0], edge[1], edge[2]["expression"])
-                            for edge in self.graph.edges.data()
-                                if len(edge) > 2 and isinstance(edge[2], Dict)
-                                    and "expression" in edge[2]]
+    def get_column_lineage_edges(self) -> Set[Tuple[Column, Column, str]]:
+        column_edges = [
+            (edge[0], edge[1], edge[2]["expression"])
+            for edge in self.graph.edges.data()
+            if len(edge) > 2 and isinstance(edge[2], Dict) and "expression" in edge[2]
+        ]
         return set(column_edges)
 
 

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -144,7 +144,7 @@ class Column:
         self._parent: Set[Union[Path, Table, SubQuery]] = set()
         self.raw_name = escape_identifier_name(name)
         self.source_columns = kwargs.pop("source_columns", ((self.raw_name, None),))
-        self.source_expression = kwargs.pop("source_expression", "")
+        self._source_expression = kwargs.pop("source_expression", "")
 
     def __str__(self):
         return (
@@ -219,5 +219,5 @@ class Column:
                 else:
                     source_columns.add(_to_src_col(src_col, Table(qualifier)))
         for src_column in source_columns:
-            src_column.source_expression = self.source_expression
+            src_column._source_expression = self._source_expression
         return source_columns

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -144,7 +144,7 @@ class Column:
         self._parent: Set[Union[Path, Table, SubQuery]] = set()
         self.raw_name = escape_identifier_name(name)
         self.source_columns = kwargs.pop("source_columns", ((self.raw_name, None),))
-        self.source_expression = kwargs.pop("source_expression", None)
+        self.source_expression = kwargs.pop("source_expression", "")
 
     def __str__(self):
         return (

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -144,6 +144,7 @@ class Column:
         self._parent: Set[Union[Path, Table, SubQuery]] = set()
         self.raw_name = escape_identifier_name(name)
         self.source_columns = kwargs.pop("source_columns", ((self.raw_name, None),))
+        self.source_expression = kwargs.pop("source_expression", None)
 
     def __str__(self):
         return (
@@ -217,4 +218,6 @@ class Column:
                     )
                 else:
                     source_columns.add(_to_src_col(src_col, Table(qualifier)))
+        for src_column in source_columns:
+            src_column.source_expression = self.source_expression
         return source_columns

--- a/sqllineage/core/parser/sqlfluff/models.py
+++ b/sqllineage/core/parser/sqlfluff/models.py
@@ -108,6 +108,7 @@ class SqlFluffColumn(Column):
                 return Column(
                     alias,
                     source_columns=source_columns,
+                    source_expression=column.raw,
                 )
             if source_columns:
                 column_name = None
@@ -141,6 +142,7 @@ class SqlFluffColumn(Column):
                 return Column(
                     column.raw if column_name is None else column_name,
                     source_columns=source_columns,
+                    source_expression=column.raw,
                 )
 
         # Wildcard, Case, Function without alias (thus not recognized as an Identifier)
@@ -148,6 +150,7 @@ class SqlFluffColumn(Column):
         return Column(
             column.raw,
             source_columns=source_columns,
+            source_expression=column.raw,
         )
 
     @staticmethod

--- a/sqllineage/core/parser/sqlparse/models.py
+++ b/sqllineage/core/parser/sqlparse/models.py
@@ -73,6 +73,7 @@ class SqlParseColumn(Column):
                 return Column(
                     alias,
                     source_columns=source_columns,
+                    source_expression=column.value,
                 )
             else:
                 # select column name directly without alias
@@ -81,6 +82,7 @@ class SqlParseColumn(Column):
                     source_columns=(
                         (column.get_real_name(), column.get_parent_name()),
                     ),
+                    source_expression=column.value,
                 )
         else:
             # Wildcard, Case, Function without alias (thus not recognized as an Identifier)
@@ -88,6 +90,7 @@ class SqlParseColumn(Column):
             return Column(
                 column.value,
                 source_columns=source_columns,
+                source_expression=column.value,
             )
 
     @staticmethod

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -155,6 +155,17 @@ Target Tables:
             key=lambda x: (str(x[-1]), str(x[0])),
         )
 
+    @lazy_method
+    def get_column_lineage_edges(self, exclude_subquery=True) -> List[Tuple[Column, Column, str]]:
+        """
+        a list of column tuple :class:`sqllineage.models.Column`
+        """
+        # sort by target column, and then source column
+        return sorted(
+            self._sql_holder.get_column_lineage_edges(exclude_subquery),
+            key=lambda x: (str(x[1]), str(x[0])),
+        )
+
     def print_column_lineage(self) -> None:
         """
         print column level lineage to stdout

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -156,13 +156,13 @@ Target Tables:
         )
 
     @lazy_method
-    def get_column_lineage_edges(self, exclude_subquery=True) -> List[Tuple[Column, Column, str]]:
+    def get_column_lineage_edges(self) -> List[Tuple[Column, Column, str]]:
         """
         a list of column tuple :class:`sqllineage.models.Column`
         """
         # sort by target column, and then source column
         return sorted(
-            self._sql_holder.get_column_lineage_edges(exclude_subquery),
+            self._sql_holder.get_column_lineage_edges(),
             key=lambda x: (str(x[1]), str(x[0])),
         )
 

--- a/tests/sql/column/test_column_select_cast.py
+++ b/tests/sql/column/test_column_select_cast.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sqllineage.utils.entities import ColumnQualifierTuple
-from ...helpers import assert_column_lineage_equal
+from ...helpers import assert_column_lineage_edges_equal, assert_column_lineage_equal
 
 
 def test_select_column_using_cast():
@@ -14,6 +14,16 @@ FROM tab2"""
             (
                 ColumnQualifierTuple("col1", "tab2"),
                 ColumnQualifierTuple("cast(col1 as timestamp)", "tab1"),
+            )
+        ],
+    )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("cast(col1 as timestamp)", "tab1"),
+                "cast(col1 AS timestamp)",
             )
         ],
     )

--- a/tests/sql/column/test_column_select_expression.py
+++ b/tests/sql/column/test_column_select_expression.py
@@ -1,5 +1,5 @@
 from sqllineage.utils.entities import ColumnQualifierTuple
-from ...helpers import assert_column_lineage_equal
+from ...helpers import assert_column_lineage_edges_equal, assert_column_lineage_equal
 
 
 def test_select_column_using_expression():
@@ -19,6 +19,21 @@ FROM tab2"""
             ),
         ],
     )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("col1 + col2", "tab1"),
+                "col1 + col2",
+            ),
+            (
+                ColumnQualifierTuple("col2", "tab2"),
+                ColumnQualifierTuple("col1 + col2", "tab1"),
+                "col1 + col2",
+            ),
+        ],
+    )
     sql = """INSERT INTO tab1
 SELECT col1 + col2 AS col3
 FROM tab2"""
@@ -32,6 +47,21 @@ FROM tab2"""
             (
                 ColumnQualifierTuple("col2", "tab2"),
                 ColumnQualifierTuple("col3", "tab1"),
+            ),
+        ],
+    )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("col3", "tab1"),
+                "col1 + col2 AS col3",
+            ),
+            (
+                ColumnQualifierTuple("col2", "tab2"),
+                ColumnQualifierTuple("col3", "tab1"),
+                "col1 + col2 AS col3",
             ),
         ],
     )

--- a/tests/sql/column/test_column_select_function.py
+++ b/tests/sql/column/test_column_select_function.py
@@ -1,5 +1,5 @@
 from sqllineage.utils.entities import ColumnQualifierTuple
-from ...helpers import assert_column_lineage_equal
+from ...helpers import assert_column_lineage_edges_equal, assert_column_lineage_equal
 
 
 def test_select_column_using_function():
@@ -20,6 +20,21 @@ FROM tab2"""
             ),
         ],
     )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("max(col1)", "tab1"),
+                "max(col1)",
+            ),
+            (
+                ColumnQualifierTuple("*", "tab2"),
+                ColumnQualifierTuple("count(*)", "tab1"),
+                "count(*)",
+            ),
+        ],
+    )
     sql = """INSERT INTO tab1
 SELECT max(col1) AS col2,
        count(*)  AS cnt
@@ -32,6 +47,21 @@ FROM tab2"""
                 ColumnQualifierTuple("col2", "tab1"),
             ),
             (ColumnQualifierTuple("*", "tab2"), ColumnQualifierTuple("cnt", "tab1")),
+        ],
+    )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "tab2"),
+                ColumnQualifierTuple("col2", "tab1"),
+                "max(col1) AS col2",
+            ),
+            (
+                ColumnQualifierTuple("*", "tab2"),
+                ColumnQualifierTuple("cnt", "tab1"),
+                "count(*)  AS cnt",
+            ),
         ],
     )
 

--- a/tests/sql/column/test_column_select_union.py
+++ b/tests/sql/column/test_column_select_union.py
@@ -1,5 +1,5 @@
 from sqllineage.utils.entities import ColumnQualifierTuple
-from ...helpers import assert_column_lineage_equal
+from ...helpers import assert_column_lineage_edges_equal, assert_column_lineage_equal
 
 
 def test_column_reference_using_union():
@@ -56,6 +56,26 @@ SELECT col1 FROM dataset.tab2) SELECT col1 FROM temp_cte"""
             (
                 ColumnQualifierTuple("col1", "dataset.tab2"),
                 ColumnQualifierTuple("col1", "dataset.target"),
+            ),
+        ],
+    )
+    assert_column_lineage_edges_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "dataset.tab1"),
+                ColumnQualifierTuple("col1", "temp_cte"),
+                "col1",
+            ),
+            (
+                ColumnQualifierTuple("col1", "temp_cte"),
+                ColumnQualifierTuple("col1", "dataset.target"),
+                "col1",
+            ),
+            (
+                ColumnQualifierTuple("col1", "dataset.tab2"),
+                ColumnQualifierTuple("col1", "temp_cte"),
+                "col1",
             ),
         ],
     )


### PR DESCRIPTION
Closes #443.

Adds `source_expression` attribute to `Column` which is populated from `BaseSegment.raw` in `SqlFluffColumn.of`.
`Column.to_source_columns` makes sure the attribute is preserved.
