### PR TITLE
feat:reset target table column name from metadata_provider

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -1,7 +1,7 @@
 from sqlfluff.core.parser import BaseSegment
 
 from sqllineage.core.holders import SubQueryLineageHolder
-from sqllineage.core.models import Path
+from sqllineage.core.models import Column, Path, Table
 from sqllineage.core.parser.sqlfluff.extractors.base import BaseExtractor
 from sqllineage.core.parser.sqlfluff.extractors.select import SelectExtractor
 from sqllineage.core.parser.sqlfluff.models import SqlFluffColumn, SqlFluffTable
@@ -9,7 +9,7 @@ from sqllineage.core.parser.sqlfluff.utils import (
     is_set_expression,
     list_child_segments,
 )
-from sqllineage.utils.entities import AnalyzerContext
+from sqllineage.utils.entities import AnalyzerContext, ColumnQualifierTuple
 from sqllineage.utils.helpers import escape_identifier_name
 
 
@@ -33,7 +33,8 @@ class CreateInsertExtractor(BaseExtractor):
     ) -> SubQueryLineageHolder:
         holder = self._init_holder(context)
         src_flag = tgt_flag = False
-        for segment in list_child_segments(statement):
+        statement_child = list_child_segments(statement)
+        for seg_idx, segment in enumerate(list_child_segments(statement)):
             if segment.type == "with_compound_statement":
                 holder |= self.delegate_to_cte(segment, holder)
             elif segment.type == "bracketed" and any(
@@ -110,6 +111,35 @@ class CreateInsertExtractor(BaseExtractor):
                     else:
                         holder.add_write(Path(escape_identifier_name(segment.raw)))
                 tgt_flag = False
+
+                if statement.type == "insert_statement" and holder.write:
+                    sub_segments = list_child_segments(
+                        segment=statement_child[seg_idx + 1]
+                    )
+                    if not all(
+                        sub_segment.type in ["column_reference", "column_definition"]
+                        for sub_segment in sub_segments
+                    ):
+                        tgt_tab = list(holder.write)[0]
+                        if isinstance(tgt_tab, Table) and tgt_tab.schema:
+                            col_list = [
+                                Column(
+                                    name=col.raw_name,
+                                    source_columns=[
+                                        ColumnQualifierTuple(
+                                            column=col.raw_name, qualifier=None
+                                        )
+                                    ],
+                                )
+                                for col in self.metadata_provider.get_table_columns(
+                                    table=Table(
+                                        name=tgt_tab.raw_name,
+                                        schema=tgt_tab.schema.raw_name,
+                                    )
+                                )
+                            ]
+                            holder.add_write_column(*col_list)
+
             if src_flag:
                 if segment.type in ["table_reference", "object_reference"]:
                     holder.add_read(SqlFluffTable.of(segment))

--- a/sqllineage/core/parser/sqlfluff/extractors/select.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/select.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlfluff.core.parser import BaseSegment
 
 from sqllineage.core.holders import SubQueryLineageHolder
@@ -24,8 +26,13 @@ class SelectExtractor(BaseExtractor, SourceHandlerMixin):
 
     SUPPORTED_STMT_TYPES = ["select_statement", "set_expression", "bracketed"]
 
-    def __init__(self, dialect: str, metadata_provider: MetaDataProvider):
-        super().__init__(dialect, metadata_provider)
+    def __init__(
+        self,
+        dialect: str,
+        metadata_provider: MetaDataProvider,
+        default_schema: Optional[str],
+    ):
+        super().__init__(dialect, metadata_provider, default_schema)
         self.columns = []
         self.tables = []
         self.union_barriers = []

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -42,6 +42,7 @@ class LineageRunner(object):
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
+        default_schema: Optional[str] = None,
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
@@ -67,6 +68,7 @@ class LineageRunner(object):
         self._dialect = dialect
         self._metadata_provider = metadata_provider
         self._silent_mode = silent_mode
+        self._default_schema = default_schema
 
     @lazy_method
     def __str__(self):
@@ -182,7 +184,9 @@ Target Tables:
         analyzer = (
             SqlParseLineageAnalyzer()
             if self._dialect == SQLPARSE_DIALECT
-            else SqlFluffLineageAnalyzer(self._dialect, self._silent_mode)
+            else SqlFluffLineageAnalyzer(
+                self._dialect, self._default_schema, self._silent_mode
+            )
         )
         if SQLLineageConfig.TSQL_NO_SEMICOLON and self._dialect == "tsql":
             self._stmt = analyzer.split_tsql(self._sql.strip())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,6 +76,7 @@ def assert_column_lineage_equal(
     metadata_provider: Optional[MetaDataProvider] = None,
     test_sqlfluff: bool = True,
     test_sqlparse: bool = True,
+    default_schema: Optional[str] = None,
 ):
     metadata_provider = (
         DummyMetaDataProvider() if metadata_provider is None else metadata_provider
@@ -84,7 +85,10 @@ def assert_column_lineage_equal(
         sql, dialect=SQLPARSE_DIALECT, metadata_provider=metadata_provider
     )
     lr_sqlfluff = LineageRunner(
-        sql, dialect=dialect, metadata_provider=metadata_provider
+        sql,
+        dialect=dialect,
+        metadata_provider=metadata_provider,
+        default_schema=default_schema,
     )
     if test_sqlparse:
         _assert_column_lineage(lr, column_lineages)

--- a/tests/sql/column/test_metadata_target_column.py
+++ b/tests/sql/column/test_metadata_target_column.py
@@ -1,0 +1,119 @@
+from typing import Dict, List, Optional
+
+from sqllineage.core.metadata_provider import MetaDataProvider
+from sqllineage.utils.entities import ColumnQualifierTuple
+from ...helpers import assert_column_lineage_equal
+
+
+class MetaCollect(MetaDataProvider):
+    def __init__(self, metadata: Optional[Dict[str, List[str]]]):
+        super().__init__()
+        self.metadata = metadata if metadata else {}
+
+    def _get_table_columns(self, schema: str, table: str, **kwargs) -> List[str]:
+        return self.metadata.get(f"{schema}.{table}", [])
+
+
+meta_collect = {
+    "ods.source_a": ["day_id", "user_id", "user_name"],
+    "ods.target_tab": ["day_no", "user_code", "name"],
+}
+
+
+def test_metadata_target_column():
+    sql = """insert into ods.target_tab select day_id as acct_id, user_id as xxx, user_name as yyy from ods.source_a"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte():
+    sql = """
+INSERT INTO ods.target_tab
+WITH cte1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+SELECT acct_id, xxx, yyy FROM cte1"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte2():
+    sql = """INSERT INTO ods.target_tab
+    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+    SELECT acct_id, xxx, yyy FROM tab1)"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte3():
+    sql = """ INSERT INTO ods.target_tab
+    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+    SELECT acct_id, xxx, yyy FROM tab1);"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )

--- a/tests/sql/column/test_metadata_target_column.py
+++ b/tests/sql/column/test_metadata_target_column.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Optional
+
+
+from typing import Optional, List, Dict
 
 from sqllineage.core.metadata_provider import MetaDataProvider
 from sqllineage.utils.entities import ColumnQualifierTuple
@@ -14,22 +16,22 @@ class MetaCollect(MetaDataProvider):
         return self.metadata.get(f"{schema}.{table}", [])
 
 
-meta_collect = {
-    "ods.source_a": ["day_id", "user_id", "user_name"],
-    "ods.target_tab": ["day_no", "user_code", "name"],
-}
+
+meta_collect = {'ods.source_a': ['day_id', 'user_id', 'user_name'],
+                'ods.target_tab': ['day_no', 'user_code', 'name'], }
 
 
 def test_metadata_target_column():
     sql = """insert into ods.target_tab select day_id as acct_id, user_id as xxx, user_name as yyy from ods.source_a"""
     assert_column_lineage_equal(
         sql=sql,
-        column_lineages=[
+        column_lineages=
+        [
+            (ColumnQualifierTuple("user_name", "ods.source_a"),
+             ColumnQualifierTuple("name", "ods.target_tab"),
+             ),
             (
-                ColumnQualifierTuple("user_name", "ods.source_a"),
-                ColumnQualifierTuple("name", "ods.target_tab"),
-            ),
-            (
+
                 ColumnQualifierTuple("day_id", "ods.source_a"),
                 ColumnQualifierTuple("day_no", "ods.target_tab"),
             ),
@@ -116,4 +118,5 @@ def test_metadata_target_column_cte3():
         ],
         metadata_provider=MetaCollect(meta_collect),
         test_sqlparse=False,
+
     )


### PR DESCRIPTION
dear reata:
  feat import target table column name from MetaDataProvider #528。

insert into target select id, name from source
target table has two column : user_id, user_name 
old result:   source.id ==> target.id   source.name ==>target.name
new result: source.id ==> target.user_id    source.name ==> target.user_name 

but if  sql is : insert into target(id, name) select id, name from source
none thing to do . 

