### PR TITLE
Set param from config

### DIFF
--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -1,28 +1,88 @@
+import dataclasses
 import os
+from dataclasses import dataclass
+from typing import Union, Any
+
+
+@dataclass
+class SQLLineageConfigValue:
+    class_type: Any
+    value: Union[str, bool, None]
+
+
+@dataclass
+class SQLLineageConfigDef:
+    DIRECTORY: SQLLineageConfigValue
+    DEFAULT_SCHEMA: SQLLineageConfigValue
+    TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
 class _SQLLineageConfigLoader:
     """
     Load all configurable items from environment variable, otherwise fallback to default
     """
+    def __init__(self):
+        self._config = SQLLineageConfigDef(
+            DIRECTORY=SQLLineageConfigValue(
+                str, os.path.join(os.path.dirname(__file__), "data")
+            ),
+            DEFAULT_SCHEMA=SQLLineageConfigValue(str, None),
+            TSQL_NO_SEMICOLON=SQLLineageConfigValue(bool, False),
+        )
 
-    # inspired by https://github.com/joke2k/django-environ
-    config = {
-        # for frontend directory drawer
-        "DIRECTORY": (str, os.path.join(os.path.dirname(__file__), "data")),
-        # set default schema/database
-        "DEFAULT_SCHEMA": (str, ""),
-        # to enable tsql no semicolon splitter mode
-        "TSQL_NO_SEMICOLON": (bool, False),
-    }
+    @property
+    def DEFAULT_SCHEMA(self):
+        return self._config.DEFAULT_SCHEMA.value
 
-    def __getattr__(self, item):
-        if item in self.config:
-            type_, default = self.config[item]
-            # require SQLLINEAGE_ prefix from environment variable
-            return type_(os.environ.get("SQLLINEAGE_" + item, default))
+    @DEFAULT_SCHEMA.setter
+    def DEFAULT_SCHEMA(self, value):
+        if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+            self._config.DEFAULT_SCHEMA.value = value
         else:
-            return super().__getattribute__(item)
+            raise
+
+    @property
+    def DIRECTORY(self):
+        return self._config.DIRECTORY.value
+
+    @DIRECTORY.setter
+    def DIRECTORY(self, value):
+        if isinstance(value, self._config.DIRECTORY.class_type):
+            self._config.DIRECTORY.value = value
+        else:
+            raise
+
+    @property
+    def TSQL_NO_SEMICOLON(self):
+        return self._config.TSQL_NO_SEMICOLON.value
+
+    @TSQL_NO_SEMICOLON.setter
+    def TSQL_NO_SEMICOLON(self, value):
+        if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
+            self._config.TSQL_NO_SEMICOLON.value = value
+        else:
+            raise
+
+    # def __getattr__(self, item):
+    #     self._config: SQLLineageConfigDef
+    #     a = dataclasses.fields(self._config)
+    #     print(a)
+        # if self._config.
+        #     if item in self.config:
+        #         return
+        #         # type_, default = self.config[item]
+        #         # # require SQLLINEAGE_ prefix from environment variable
+        #         # return type_(os.environ.get("SQLLINEAGE_" + item, default))
+        #     else:
+        #         return super().__getattribute__(item)
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
+
+if __name__ == "__main__":
+    SQLLineageConfig.DIRECTORY = "xxx"
+    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
+    SQLLineageConfig.TSQL_NO_SEMICOLON = True
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -2,7 +2,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, Union
 
-
 @dataclass
 class SQLLineageConfigValue:
     class_type: Any
@@ -10,18 +9,18 @@ class SQLLineageConfigValue:
 
 
 @dataclass
-class SQLLineageConfigDef:
+class SQLLineageConfigDef():
     DIRECTORY: SQLLineageConfigValue
     DEFAULT_SCHEMA: SQLLineageConfigValue
     TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
-class _SQLLineageConfigLoader:
+class _SQLLineageConfigLoader() :
     """
-    Load all configurable items from config variable, otherwise fallback to default
+    Load all configurable items from environment variable, otherwise fallback to default
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._config = SQLLineageConfigDef(
             DIRECTORY=SQLLineageConfigValue(
                 str, os.path.join(os.path.dirname(__file__), "data")
@@ -35,43 +34,48 @@ class _SQLLineageConfigLoader:
         return self._config.DEFAULT_SCHEMA.value
 
     @DEFAULT_SCHEMA.setter
-    def DEFAULT_SCHEMA(self, value: str):
-        if (
-            value and isinstance(value, self._config.DEFAULT_SCHEMA.class_type)
-        ) or value is None:
-            self._config.DEFAULT_SCHEMA.value = value
-        else:
-            raise ValueError(
-                f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
-            )
+    def DEFAULT_SCHEMA(self, value):
+        if value:
+            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+                self._config.DEFAULT_SCHEMA.value = value
+            else:
+                raise ValueError(
+                    f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
+                )
 
     @property
     def DIRECTORY(self):
         return self._config.DIRECTORY.value
 
     @DIRECTORY.setter
-    def DIRECTORY(self, value: str):
-        if value is None:
-            value = os.path.join(os.path.dirname(__file__), "data")
-        if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-            self._config.DIRECTORY.value = value
-        else:
-            raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
+    def DIRECTORY(self, value):
+        if value:
+            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+                self._config.DIRECTORY.value = value
+            else:
+                raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
 
     @property
     def TSQL_NO_SEMICOLON(self):
         return self._config.TSQL_NO_SEMICOLON.value
 
     @TSQL_NO_SEMICOLON.setter
-    def TSQL_NO_SEMICOLON(self, value: bool):
-        if value is None:
-            value = False
-        if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
-            self._config.TSQL_NO_SEMICOLON.value = value
-        else:
-            raise ValueError(
-                f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
-            )
+    def TSQL_NO_SEMICOLON(self, value):
+        if value :
+            if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
+                self._config.TSQL_NO_SEMICOLON.value = value
+            else:
+                raise ValueError(
+                    f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
+                )
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
+
+if __name__ == "__main__":
+    SQLLineageConfig.DIRECTORY = "xxx"
+    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
+    SQLLineageConfig.TSQL_NO_SEMICOLON = "xxx"
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -35,50 +35,43 @@ class _SQLLineageConfigLoader:
         return self._config.DEFAULT_SCHEMA.value
 
     @DEFAULT_SCHEMA.setter
-    def DEFAULT_SCHEMA(self, value):
-        if value:
-            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-                self._config.DEFAULT_SCHEMA.value = value
-            else:
-                raise ValueError(
-                    f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
-                )
+    def DEFAULT_SCHEMA(self, value: str):
+        if (
+            value and isinstance(value, self._config.DEFAULT_SCHEMA.class_type)
+        ) or value is None:
+            self._config.DEFAULT_SCHEMA.value = value
+        else:
+            raise ValueError(
+                f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
+            )
 
     @property
     def DIRECTORY(self):
         return self._config.DIRECTORY.value
 
     @DIRECTORY.setter
-    def DIRECTORY(self, value):
-        if value:
-            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-                self._config.DIRECTORY.value = value
-            else:
-                raise ValueError(
-                    f"DIRECTORY should be {self._config.DIRECTORY.class_type}"
-                )
+    def DIRECTORY(self, value: str):
+        if value is None:
+            value = os.path.join(os.path.dirname(__file__), "data")
+        if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+            self._config.DIRECTORY.value = value
+        else:
+            raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
 
     @property
     def TSQL_NO_SEMICOLON(self):
         return self._config.TSQL_NO_SEMICOLON.value
 
     @TSQL_NO_SEMICOLON.setter
-    def TSQL_NO_SEMICOLON(self, value):
-        if value:
-            if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
-                self._config.TSQL_NO_SEMICOLON.value = value
-            else:
-                raise ValueError(
-                    f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
-                )
+    def TSQL_NO_SEMICOLON(self, value: bool):
+        if value is None:
+            value = False
+        if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
+            self._config.TSQL_NO_SEMICOLON.value = value
+        else:
+            raise ValueError(
+                f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
+            )
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
-
-if __name__ == "__main__":
-    SQLLineageConfig.DIRECTORY = "xxx"
-    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
-    SQLLineageConfig.TSQL_NO_SEMICOLON = "xxx"
-    print(SQLLineageConfig.DIRECTORY)
-    print(SQLLineageConfig.DEFAULT_SCHEMA)
-    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -3,32 +3,43 @@ import os
 
 class _SQLLineageConfigLoader:
     """
-    Load all configurable items from environment variable, otherwise fallback to default
+    Load all configurable items from config variable, otherwise fallback to default
     """
 
-    # inspired by https://github.com/joke2k/django-environ
-    config = {
-        # for frontend directory drawer
-        "DIRECTORY": (str, os.path.join(os.path.dirname(__file__), "data")),
-        # set default schema/database
-        "DEFAULT_SCHEMA": (str, ""),
-        # to enable tsql no semicolon splitter mode
-        "TSQL_NO_SEMICOLON": (bool, False),
-    }
-    BOOLEAN_TRUE_STRINGS = ("true", "on", "ok", "y", "yes", "1")
+    def __init__(self) -> None:
+        self._init = False
 
-    def __getattr__(self, item):
-        if item in self.config:
-            type_, default = self.config[item]
-            # require SQLLINEAGE_ prefix from environment variable
-            return self.parse_value(
-                os.environ.get("SQLLINEAGE_" + item, default), type_
+        self._config = {
+            "DIRECTORY": {
+                "class_type": str,
+                "additional": None,
+                "default": os.path.join(os.path.dirname(__file__), "data"),
+            },
+            "DEFAULT_SCHEMA": {
+                "class_type": str,
+                "additional": None,
+                "default": None,
+            },
+            "TSQL_NO_SEMICOLON": {
+                "class_type": bool,
+                "additional": None,
+                "default": False,
+            },
+        }
+
+        self._PREFIX = "SQLLINEAGE_"
+        self._BOOLEAN_TRUE_STRINGS = ("true", "on", "ok", "y", "yes", "1")
+        self._len_prefix = len(self._PREFIX)
+        self._init = True
+
+        for item in set(
+            [self._PREFIX + key for key in self._config.keys()]
+        ).intersection(set(os.environ.keys())):
+            self._config[item[self._len_prefix :]]["os_env"] = self.parse_value(
+                os.environ[item], self._config[item]["class_type"]
             )
-        else:
-            return super().__getattribute__(item)
 
-    @classmethod
-    def parse_value(cls, value, cast):
+    def parse_value(self, value, cast):
         """Parse and cast provided value
 
         :param value: Stringed value.
@@ -40,11 +51,64 @@ class _SQLLineageConfigLoader:
             try:
                 value = int(value) != 0
             except ValueError:
-                value = value.lower().strip() in cls.BOOLEAN_TRUE_STRINGS
+                value = value.lower().strip() in self._BOOLEAN_TRUE_STRINGS
         else:
             value = cast(value)
 
         return value
 
+    def __getattr__(self, item):
+        if not self._init:
+            super().__getattribute__(item)
+        else:
+            if self._config[item]["additional"] is not None:
+                return self._config[item]["additional"]
+            elif (os_env_item := self._PREFIX + item) in os.environ.keys():
+                return self.parse_value(
+                    os.environ[os_env_item], self._config[item]["class_type"]
+                )
+            else:
+                return self._config[item]["default"]
+
+    def __setattr__(self, key, value):
+        if key == "_init" or not self._init:
+            super().__setattr__(key, value)
+        else:
+            if key not in [field for field in self._config.keys()]:
+                raise ValueError(f"config {key} is not support")
+
+            if value is None or isinstance(value, self._config[key]["class_type"]):
+                if key == "DIRECTORY" and value and not os.path.isdir(value):
+                    raise NotADirectoryError(f"{value} does not exist")
+                self._config[key]["additional"] = value
+            else:
+                raise ValueError(f"{key}:{value} class type incorrect")
+
 
 SQLLineageConfig = _SQLLineageConfigLoader()
+
+
+if __name__ == "__main__":
+    #   DIRECTORY: SQLLineageConfigValue
+    #     DEFAULT_SCHEMA: SQLLineageConfigValue
+    #     TSQL_NO_SEMICOLON: SQLLineageConfigValue
+
+    # os.environ[
+    #     "SQLLINEAGE_DIRECTORY"
+    # ] = "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage"
+    # os.environ["SQLLINEAGE_DEFAULT_SCHEMA"] = "lll"
+    # os.environ["SQLLINEAGE_TSQL_NO_SEMICOLON"] = "False"
+
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)
+
+    SQLLineageConfig.DIRECTORY = (
+        "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage/sqllineage/"
+    )
+    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
+    SQLLineageConfig.TSQL_NO_SEMICOLON = True
+
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -1,8 +1,6 @@
-import dataclasses
 import os
 from dataclasses import dataclass
-from typing import Union, Any
-
+from typing import Any, Union
 
 @dataclass
 class SQLLineageConfigValue:
@@ -11,16 +9,17 @@ class SQLLineageConfigValue:
 
 
 @dataclass
-class SQLLineageConfigDef:
+class SQLLineageConfigDef():
     DIRECTORY: SQLLineageConfigValue
     DEFAULT_SCHEMA: SQLLineageConfigValue
     TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
-class _SQLLineageConfigLoader:
+class _SQLLineageConfigLoader() :
     """
     Load all configurable items from environment variable, otherwise fallback to default
     """
+
     def __init__(self):
         self._config = SQLLineageConfigDef(
             DIRECTORY=SQLLineageConfigValue(
@@ -36,10 +35,13 @@ class _SQLLineageConfigLoader:
 
     @DEFAULT_SCHEMA.setter
     def DEFAULT_SCHEMA(self, value):
-        if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-            self._config.DEFAULT_SCHEMA.value = value
-        else:
-            raise
+        if value:
+            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+                self._config.DEFAULT_SCHEMA.value = value
+            else:
+                raise ValueError(
+                    f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
+                )
 
     @property
     def DIRECTORY(self):
@@ -47,10 +49,11 @@ class _SQLLineageConfigLoader:
 
     @DIRECTORY.setter
     def DIRECTORY(self, value):
-        if isinstance(value, self._config.DIRECTORY.class_type):
-            self._config.DIRECTORY.value = value
-        else:
-            raise
+        if value:
+            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
+                self._config.DIRECTORY.value = value
+            else:
+                raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
 
     @property
     def TSQL_NO_SEMICOLON(self):
@@ -58,23 +61,13 @@ class _SQLLineageConfigLoader:
 
     @TSQL_NO_SEMICOLON.setter
     def TSQL_NO_SEMICOLON(self, value):
-        if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
-            self._config.TSQL_NO_SEMICOLON.value = value
-        else:
-            raise
-
-    # def __getattr__(self, item):
-    #     self._config: SQLLineageConfigDef
-    #     a = dataclasses.fields(self._config)
-    #     print(a)
-        # if self._config.
-        #     if item in self.config:
-        #         return
-        #         # type_, default = self.config[item]
-        #         # # require SQLLINEAGE_ prefix from environment variable
-        #         # return type_(os.environ.get("SQLLINEAGE_" + item, default))
-        #     else:
-        #         return super().__getattribute__(item)
+        if value :
+            if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
+                self._config.TSQL_NO_SEMICOLON.value = value
+            else:
+                raise ValueError(
+                    f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
+                )
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
@@ -82,7 +75,7 @@ SQLLineageConfig = _SQLLineageConfigLoader()
 if __name__ == "__main__":
     SQLLineageConfig.DIRECTORY = "xxx"
     SQLLineageConfig.DEFAULT_SCHEMA = "ods"
-    SQLLineageConfig.TSQL_NO_SEMICOLON = True
+    SQLLineageConfig.TSQL_NO_SEMICOLON = "xxx"
     print(SQLLineageConfig.DIRECTORY)
     print(SQLLineageConfig.DEFAULT_SCHEMA)
     print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -1,119 +1,97 @@
 import os
-from collections import namedtuple
-from dataclasses import dataclass
-from enum import auto
-from typing import Any, Union
-
-from pip._internal.utils.misc import enum
-
-#
-# class SQLLineageConfigKey(enum):
-#     DIRECTORY=auto()
-#     DEFAULT_SCHEMA=auto()
-#     TSQL_NO_SEMICOLON=auto()
-#
-@dataclass
-class SQLLineageConfigValue:
-    class_type: Any
-    value: Union[str, bool, None]
-
-#
-@dataclass
-class SQLLineageConfigDef:
-    DIRECTORY: SQLLineageConfigValue
-    DEFAULT_SCHEMA: SQLLineageConfigValue
-    TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
 class _SQLLineageConfigLoader:
     """
     Load all configurable items from config variable, otherwise fallback to default
     """
+
     def __init__(self) -> None:
-        # SQLLineageConfigDef = namedtuple('SQLLineageConfigDef', ['class', 'value'])
+        self._init = False
+
         self._config = {
             "DIRECTORY": {
                 "class_type": str,
-                "value": {
-                    "additional": None,
-                    "os_env": None,
-                    "default": os.path.join(os.path.dirname(__file__), "data"),
-                },
+                "additional": None,
+                "os_env": None,
+                "default": os.path.join(os.path.dirname(__file__), "data"),
             },
             "DEFAULT_SCHEMA": {
                 "class_type": str,
-                "value": {
-                    "additional": None,
-                    "os_env": None,
-                    "default": None,
-                },
+                "additional": None,
+                "os_env": None,
+                "default": None,
             },
             "TSQL_NO_SEMICOLON": {
                 "class_type": bool,
-                "value": {"additional": None, "os_env": None, "default": False},
+                "additional": None,
+                "os_env": None,
+                "default": False,
             },
         }
 
         self._prefix = "SQLLINEAGE_"
         self._len_prefix = len(self._prefix)
+        self._init = True
 
         for item in set(
             [self._prefix + key for key in self._config.keys()]
         ).intersection(set(os.environ.keys())):
-            self._config[item[self._len_prefix :]] = os.environ[item]
+            self._config[item[self._len_prefix :]]["os_env"] = os.environ[item]
 
-    @property
-    def DEFAULT_SCHEMA(self):
-        for key, value in self._config["DEFAULT_SCHEMA"]["value"]:
-            if value or key == "default":
-                return value
-
-    @DEFAULT_SCHEMA.setter
-    def DEFAULT_SCHEMA(self, value: str):
-        if (
-            value and isinstance(value, self._config["DEFAULT_SCHEMA"]["class_type"])
-        ) or value is None:
-            self._config["DEFAULT_SCHEMA"]["value"]["additional"] = value
+    def __getattr__(self, item):
+        if not self._init:
+            super().__getattribute__(item)
         else:
-            raise ValueError(
-                f"DEFAULT_SCHEMA should be {self._config['DEFAULT_SCHEMA']['class_type']}"
-            )
+            for field in self._config[item].keys():
+                if field == "class_type":
+                    continue
+                if (value := self._config[item][field]) or field == "default":
+                    return value
 
-    @property
-    def DIRECTORY(self):
-        for key, value in self._config["DIRECTORY"]["value"]:
-            if value or key == "default":
-                return value
-
-    @DIRECTORY.setter
-    def DIRECTORY(self, value: str):
-        if value is None:
-            self._config["DIRECTORY"]["value"]["additional"] = value
+    def __setattr__(self, key, value):
+        if key == "_init" or not self._init:
+            super().__setattr__(key, value)
         else:
-            assert isinstance(
-                value, self._config["DIRECTORY"]["class_type"]
-            ), ValueError(
-                f"DIRECTORY should be {self._config['DIRECTORY']['class_type']}"
-            )
-            assert os.path.isdir(value), NotADirectoryError(f"DIRECTORY does not exits")
-            self._config["DIRECTORY"]["value"]["additional"] = value
+            if key not in [field for field in self._config.keys()]:
+                raise ValueError(f"{key} is not support")
 
-    @property
-    def TSQL_NO_SEMICOLON(self):
-        for key, value in self._config["TSQL_NO_SEMICOLON"]["value"]:
-            if value or key == "default":
-                return value
+            if value is None or isinstance(value, self._config[key]["class_type"]):
+                if key == "DIRECTORY" and value and not os.path.isdir(value):
+                    raise NotADirectoryError(f"{value} does not exist")
+                self._config[key]["additional"] = value
+            else:
+                raise ValueError(f"{key}:{value} class type incorrect")
 
-    @TSQL_NO_SEMICOLON.setter
-    def TSQL_NO_SEMICOLON(self, value: bool):
-        if (
-            value and isinstance(value, self._config["TSQL_NO_SEMICOLON"]["class_type"])
-        ) or value is None:
-            self._config["TSQL_NO_SEMICOLON"]["value"]["additional"] = value
-        else:
-            raise ValueError(
-                f"TSQL_NO_SEMICOLON should be {self._config['TSQL_NO_SEMICOLON']['class_type']}"
-            )
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
+
+
+if __name__ == "__main__":
+    #   DIRECTORY: SQLLineageConfigValue
+    #     DEFAULT_SCHEMA: SQLLineageConfigValue
+    #     TSQL_NO_SEMICOLON: SQLLineageConfigValue
+
+
+
+# os.environ[
+#     "SQLLINEAGE_DIRECTORY"
+# ] = "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage"
+# os.environ["SQLLINEAGE_DEFAULT_SCHEMA"] = "lll"
+# os.environ["SQLLINEAGE_TSQL_NO_SEMICOLON"] = "False"
+
+
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)
+
+    SQLLineageConfig.DIRECTORY = (
+        "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage/sqllineage/"
+    )
+    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
+    SQLLineageConfig.TSQL_NO_SEMICOLON = True
+
+    print(SQLLineageConfig.DIRECTORY)
+    print(SQLLineageConfig.DEFAULT_SCHEMA)
+    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -64,34 +64,4 @@ class _SQLLineageConfigLoader:
                 raise ValueError(f"{key}:{value} class type incorrect")
 
 
-
 SQLLineageConfig = _SQLLineageConfigLoader()
-
-
-if __name__ == "__main__":
-    #   DIRECTORY: SQLLineageConfigValue
-    #     DEFAULT_SCHEMA: SQLLineageConfigValue
-    #     TSQL_NO_SEMICOLON: SQLLineageConfigValue
-
-
-
-# os.environ[
-#     "SQLLINEAGE_DIRECTORY"
-# ] = "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage"
-# os.environ["SQLLINEAGE_DEFAULT_SCHEMA"] = "lll"
-# os.environ["SQLLINEAGE_TSQL_NO_SEMICOLON"] = "False"
-
-
-    print(SQLLineageConfig.DIRECTORY)
-    print(SQLLineageConfig.DEFAULT_SCHEMA)
-    print(SQLLineageConfig.TSQL_NO_SEMICOLON)
-
-    SQLLineageConfig.DIRECTORY = (
-        "/Users/liuzhou/工作/亚信/工具开发/sqllineage_github/sqllineage/sqllineage/"
-    )
-    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
-    SQLLineageConfig.TSQL_NO_SEMICOLON = True
-
-    print(SQLLineageConfig.DIRECTORY)
-    print(SQLLineageConfig.DEFAULT_SCHEMA)
-    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -1,81 +1,119 @@
 import os
+from collections import namedtuple
 from dataclasses import dataclass
+from enum import auto
 from typing import Any, Union
 
+from pip._internal.utils.misc import enum
+
+#
+# class SQLLineageConfigKey(enum):
+#     DIRECTORY=auto()
+#     DEFAULT_SCHEMA=auto()
+#     TSQL_NO_SEMICOLON=auto()
+#
 @dataclass
 class SQLLineageConfigValue:
     class_type: Any
     value: Union[str, bool, None]
 
-
+#
 @dataclass
-class SQLLineageConfigDef():
+class SQLLineageConfigDef:
     DIRECTORY: SQLLineageConfigValue
     DEFAULT_SCHEMA: SQLLineageConfigValue
     TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
-class _SQLLineageConfigLoader() :
+class _SQLLineageConfigLoader:
     """
-    Load all configurable items from environment variable, otherwise fallback to default
+    Load all configurable items from config variable, otherwise fallback to default
     """
+    def __init__(self) -> None:
+        # SQLLineageConfigDef = namedtuple('SQLLineageConfigDef', ['class', 'value'])
+        self._config = {
+            "DIRECTORY": {
+                "class_type": str,
+                "value": {
+                    "additional": None,
+                    "os_env": None,
+                    "default": os.path.join(os.path.dirname(__file__), "data"),
+                },
+            },
+            "DEFAULT_SCHEMA": {
+                "class_type": str,
+                "value": {
+                    "additional": None,
+                    "os_env": None,
+                    "default": None,
+                },
+            },
+            "TSQL_NO_SEMICOLON": {
+                "class_type": bool,
+                "value": {"additional": None, "os_env": None, "default": False},
+            },
+        }
 
-    def __init__(self):
-        self._config = SQLLineageConfigDef(
-            DIRECTORY=SQLLineageConfigValue(
-                str, os.path.join(os.path.dirname(__file__), "data")
-            ),
-            DEFAULT_SCHEMA=SQLLineageConfigValue(str, None),
-            TSQL_NO_SEMICOLON=SQLLineageConfigValue(bool, False),
-        )
+        self._prefix = "SQLLINEAGE_"
+        self._len_prefix = len(self._prefix)
+
+        for item in set(
+            [self._prefix + key for key in self._config.keys()]
+        ).intersection(set(os.environ.keys())):
+            self._config[item[self._len_prefix :]] = os.environ[item]
 
     @property
     def DEFAULT_SCHEMA(self):
-        return self._config.DEFAULT_SCHEMA.value
+        for key, value in self._config["DEFAULT_SCHEMA"]["value"]:
+            if value or key == "default":
+                return value
 
     @DEFAULT_SCHEMA.setter
-    def DEFAULT_SCHEMA(self, value):
-        if value:
-            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-                self._config.DEFAULT_SCHEMA.value = value
-            else:
-                raise ValueError(
-                    f"DEFAULT_SCHEMA should be {self._config.DEFAULT_SCHEMA.class_type}"
-                )
+    def DEFAULT_SCHEMA(self, value: str):
+        if (
+            value and isinstance(value, self._config["DEFAULT_SCHEMA"]["class_type"])
+        ) or value is None:
+            self._config["DEFAULT_SCHEMA"]["value"]["additional"] = value
+        else:
+            raise ValueError(
+                f"DEFAULT_SCHEMA should be {self._config['DEFAULT_SCHEMA']['class_type']}"
+            )
 
     @property
     def DIRECTORY(self):
-        return self._config.DIRECTORY.value
+        for key, value in self._config["DIRECTORY"]["value"]:
+            if value or key == "default":
+                return value
 
     @DIRECTORY.setter
-    def DIRECTORY(self, value):
-        if value:
-            if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
-                self._config.DIRECTORY.value = value
-            else:
-                raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
+    def DIRECTORY(self, value: str):
+        if value is None:
+            self._config["DIRECTORY"]["value"]["additional"] = value
+        else:
+            assert isinstance(
+                value, self._config["DIRECTORY"]["class_type"]
+            ), ValueError(
+                f"DIRECTORY should be {self._config['DIRECTORY']['class_type']}"
+            )
+            assert os.path.isdir(value), NotADirectoryError(f"DIRECTORY does not exits")
+            self._config["DIRECTORY"]["value"]["additional"] = value
 
     @property
     def TSQL_NO_SEMICOLON(self):
-        return self._config.TSQL_NO_SEMICOLON.value
+        for key, value in self._config["TSQL_NO_SEMICOLON"]["value"]:
+            if value or key == "default":
+                return value
 
     @TSQL_NO_SEMICOLON.setter
-    def TSQL_NO_SEMICOLON(self, value):
-        if value :
-            if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
-                self._config.TSQL_NO_SEMICOLON.value = value
-            else:
-                raise ValueError(
-                    f"TSQL_NO_SEMICOLON should be {self._config.TSQL_NO_SEMICOLON.class_type}"
-                )
+    def TSQL_NO_SEMICOLON(self, value: bool):
+        if (
+            value and isinstance(value, self._config["TSQL_NO_SEMICOLON"]["class_type"])
+        ) or value is None:
+            self._config["TSQL_NO_SEMICOLON"]["value"]["additional"] = value
+        else:
+            raise ValueError(
+                f"TSQL_NO_SEMICOLON should be {self._config['TSQL_NO_SEMICOLON']['class_type']}"
+            )
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()
-
-if __name__ == "__main__":
-    SQLLineageConfig.DIRECTORY = "xxx"
-    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
-    SQLLineageConfig.TSQL_NO_SEMICOLON = "xxx"
-    print(SQLLineageConfig.DIRECTORY)
-    print(SQLLineageConfig.DEFAULT_SCHEMA)
-    print(SQLLineageConfig.TSQL_NO_SEMICOLON)

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Union
 
+
 @dataclass
 class SQLLineageConfigValue:
     class_type: Any
@@ -9,18 +10,18 @@ class SQLLineageConfigValue:
 
 
 @dataclass
-class SQLLineageConfigDef():
+class SQLLineageConfigDef:
     DIRECTORY: SQLLineageConfigValue
     DEFAULT_SCHEMA: SQLLineageConfigValue
     TSQL_NO_SEMICOLON: SQLLineageConfigValue
 
 
-class _SQLLineageConfigLoader() :
+class _SQLLineageConfigLoader:
     """
-    Load all configurable items from environment variable, otherwise fallback to default
+    Load all configurable items from config variable, otherwise fallback to default
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._config = SQLLineageConfigDef(
             DIRECTORY=SQLLineageConfigValue(
                 str, os.path.join(os.path.dirname(__file__), "data")
@@ -53,7 +54,9 @@ class _SQLLineageConfigLoader() :
             if isinstance(value, self._config.DEFAULT_SCHEMA.class_type):
                 self._config.DIRECTORY.value = value
             else:
-                raise ValueError(f"DIRECTORY should be {self._config.DIRECTORY.class_type}")
+                raise ValueError(
+                    f"DIRECTORY should be {self._config.DIRECTORY.class_type}"
+                )
 
     @property
     def TSQL_NO_SEMICOLON(self):
@@ -61,7 +64,7 @@ class _SQLLineageConfigLoader() :
 
     @TSQL_NO_SEMICOLON.setter
     def TSQL_NO_SEMICOLON(self, value):
-        if value :
+        if value:
             if isinstance(value, self._config.TSQL_NO_SEMICOLON.class_type):
                 self._config.TSQL_NO_SEMICOLON.value = value
             else:

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -5,7 +5,7 @@ import networkx as nx
 from networkx import DiGraph
 
 from sqllineage.core.metadata_provider import MetaDataProvider
-from sqllineage.core.models import Column, Path, Schema, SubQuery, Table
+from sqllineage.core.models import Column, Path, schema_unknown, SubQuery, Table
 from sqllineage.exceptions import InvalidSyntaxException
 from sqllineage.utils.constant import EdgeTag, EdgeType, NodeTag
 
@@ -432,7 +432,7 @@ class SQLLineageHolder(ColumnLineageMixin):
                 for parent in unresolved_col.parent_candidates:
                     if (
                         isinstance(parent, Table)
-                        and str(parent.schema) != Schema.unknown
+                        and str(parent.schema) != schema_unknown
                     ):
                         columns = metadata_provider.get_table_columns(parent)
                         for src_col in columns:

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -5,7 +5,7 @@ import networkx as nx
 from networkx import DiGraph
 
 from sqllineage.core.metadata_provider import MetaDataProvider
-from sqllineage.core.models import Column, Path, schema_unknown, SubQuery, Table
+from sqllineage.core.models import Column, Path, SubQuery, Table, schema_unknown
 from sqllineage.exceptions import InvalidSyntaxException
 from sqllineage.utils.constant import EdgeTag, EdgeType, NodeTag
 

--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -5,19 +5,20 @@ from sqllineage.config import SQLLineageConfig
 from sqllineage.exceptions import SQLLineageException
 from sqllineage.utils.helpers import escape_identifier_name
 
+schema_unknown = "<default>"
+
 
 class Schema:
     """
     Data Class for Schema
     """
 
-    unknown = "<default>"
-    default = SQLLineageConfig.DEFAULT_SCHEMA or unknown
-
-    def __init__(self, name: str = default):
+    def __init__(self, name: str = schema_unknown):
         """
         :param name: schema name
         """
+        if name == schema_unknown and SQLLineageConfig.DEFAULT_SCHEMA:
+            name = SQLLineageConfig.DEFAULT_SCHEMA
         self.raw_name = escape_identifier_name(name)
 
     def __str__(self):
@@ -33,7 +34,7 @@ class Schema:
         return hash(str(self))
 
     def __bool__(self):
-        return str(self) != self.default
+        return str(self) != schema_unknown
 
 
 class Table:

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -183,6 +183,7 @@ Target Tables:
         print(str(self))
 
     def _eval(self):
+
         analyzer = (
             SqlParseLineageAnalyzer()
             if self._dialect == SQLPARSE_DIALECT

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -183,7 +183,6 @@ Target Tables:
         print(str(self))
 
     def _eval(self):
-
         analyzer = (
             SqlParseLineageAnalyzer()
             if self._dialect == SQLPARSE_DIALECT

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -42,7 +42,8 @@ class LineageRunner(object):
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
-        default_schema:Optional[str ]=None,
+        default_schema: Optional[str] = None,
+        tsql_no_semicolon: Optional[bool] = False,
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
@@ -68,8 +69,8 @@ class LineageRunner(object):
         self._dialect = dialect
         self._metadata_provider = metadata_provider
         self._silent_mode = silent_mode
-        SQLLineageConfig.DEFAULT_SCHEMA=default_schema
-        SQLLineageConfig.TSQL_NO_SEMICOLON=
+        SQLLineageConfig.DEFAULT_SCHEMA = default_schema
+        SQLLineageConfig.TSQL_NO_SEMICOLON = tsql_no_semicolon
 
     @lazy_method
     def __str__(self):
@@ -182,6 +183,7 @@ Target Tables:
         print(str(self))
 
     def _eval(self):
+
         analyzer = (
             SqlParseLineageAnalyzer()
             if self._dialect == SQLPARSE_DIALECT

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -42,8 +42,6 @@ class LineageRunner(object):
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
-        default_schema: Optional[str] = None,
-        tsql_no_semicolon: Optional[bool] = False,
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
@@ -69,9 +67,6 @@ class LineageRunner(object):
         self._dialect = dialect
         self._metadata_provider = metadata_provider
         self._silent_mode = silent_mode
-        SQLLineageConfig.DEFAULT_SCHEMA = default_schema
-        SQLLineageConfig.TSQL_NO_SEMICOLON = tsql_no_semicolon
-
 
     @lazy_method
     def __str__(self):

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -42,6 +42,7 @@ class LineageRunner(object):
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
+        default_schema:Optional[str ]=None,
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
@@ -67,6 +68,8 @@ class LineageRunner(object):
         self._dialect = dialect
         self._metadata_provider = metadata_provider
         self._silent_mode = silent_mode
+        SQLLineageConfig.DEFAULT_SCHEMA=default_schema
+        SQLLineageConfig.TSQL_NO_SEMICOLON=
 
     @lazy_method
     def __str__(self):

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -42,8 +42,6 @@ class LineageRunner(object):
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, str]] = None,
-        default_schema: Optional[str] = None,
-        tsql_no_semicolon: Optional[bool] = False,
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
@@ -69,8 +67,7 @@ class LineageRunner(object):
         self._dialect = dialect
         self._metadata_provider = metadata_provider
         self._silent_mode = silent_mode
-        SQLLineageConfig.DEFAULT_SCHEMA = default_schema
-        SQLLineageConfig.TSQL_NO_SEMICOLON = tsql_no_semicolon
+
 
     @lazy_method
     def __str__(self):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,38 @@
+import os
+from unittest.mock import patch
+
+from sqllineage.config import SQLLineageConfig
+
+
+@patch(
+    "os.environ",
+    {
+        "SQLLINEAGE_DIRECTORY": os.path.join(os.path.dirname(__file__), "data"),
+        "SQLLINEAGE_DEFAULT_SCHEMA": "<default>",
+        "SQLLINEAGE_TSQL_NO_SEMICOLON": "true",
+    },
+)
+def test_config():
+    assert type(SQLLineageConfig.DIRECTORY) is str
+    assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "data")
+
+    assert type(SQLLineageConfig.DEFAULT_SCHEMA) is str
+    assert SQLLineageConfig.DEFAULT_SCHEMA == "<default>"
+
+    assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
+    assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
+
+def test_config_reset():
+    SQLLineageConfig.DIRECTORY=os.path.join(os.path.dirname(__file__), "")
+    assert type(SQLLineageConfig.DIRECTORY) is str
+    assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "")
+
+    SQLLineageConfig.DEFAULT_SCHEMA="ods"
+    assert type(SQLLineageConfig.DEFAULT_SCHEMA) is str
+    assert SQLLineageConfig.DEFAULT_SCHEMA == "ods"
+
+    SQLLineageConfig.TSQL_NO_SEMICOLON = True
+    assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
+    assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
+
+

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,14 @@
 import os
 from unittest.mock import patch
+
 from sqllineage.config import SQLLineageConfig
+
+
+def test_config_default():
+    assert type(SQLLineageConfig.DIRECTORY) is str
+    assert SQLLineageConfig.DEFAULT_SCHEMA is None
+    assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
+    assert SQLLineageConfig.TSQL_NO_SEMICOLON is False
 
 
 @patch(
@@ -12,7 +20,6 @@ from sqllineage.config import SQLLineageConfig
     },
 )
 def test_config():
-    print(os.environ['SQLLINEAGE_DIRECTORY'])
     assert type(SQLLineageConfig.DIRECTORY) is str
     assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "data")
 
@@ -22,12 +29,31 @@ def test_config():
     assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
     assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
 
-def test_config_reset():
-    SQLLineageConfig.DIRECTORY=os.path.join(os.path.dirname(__file__), "")
-    assert type(SQLLineageConfig.DIRECTORY) is str
-    assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "")
 
-    SQLLineageConfig.DEFAULT_SCHEMA="ods"
+def test_config_exception():
+    is_exception = False
+    try:
+        SQLLineageConfig.DIRECTORYxxx = "xxx"
+    except ValueError:
+        is_exception = True
+    assert is_exception
+
+
+def test_config_exception2():
+    is_exception = False
+    try:
+        SQLLineageConfig.DIRECTORY = "xxx"
+    except NotADirectoryError:
+        is_exception = True
+    assert is_exception
+
+
+def test_config_reset():
+    SQLLineageConfig.DIRECTORY = os.path.dirname(__file__)
+    assert type(SQLLineageConfig.DIRECTORY) is str
+    assert SQLLineageConfig.DIRECTORY == os.path.dirname(__file__)
+
+    SQLLineageConfig.DEFAULT_SCHEMA = "ods"
     assert type(SQLLineageConfig.DEFAULT_SCHEMA) is str
     assert SQLLineageConfig.DEFAULT_SCHEMA == "ods"
 
@@ -35,10 +61,6 @@ def test_config_reset():
     assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
     assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
 
-    SQLLineageConfig.DIRECTORY=None
-    SQLLineageConfig.DEFAULT_SCHEMA=None
-    SQLLineageConfig.TSQL_NO_SEMICOLON=None
-
-
-
-
+    SQLLineageConfig.DIRECTORY = None
+    SQLLineageConfig.DEFAULT_SCHEMA = None
+    SQLLineageConfig.TSQL_NO_SEMICOLON = None

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,5 @@
 import os
 from unittest.mock import patch
-
 from sqllineage.config import SQLLineageConfig
 
 
@@ -13,6 +12,7 @@ from sqllineage.config import SQLLineageConfig
     },
 )
 def test_config():
+    print(os.environ['SQLLINEAGE_DIRECTORY'])
     assert type(SQLLineageConfig.DIRECTORY) is str
     assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "data")
 
@@ -34,5 +34,11 @@ def test_config_reset():
     SQLLineageConfig.TSQL_NO_SEMICOLON = True
     assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
     assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
+
+    SQLLineageConfig.DIRECTORY=None
+    SQLLineageConfig.DEFAULT_SCHEMA=None
+    SQLLineageConfig.TSQL_NO_SEMICOLON=None
+
+
 
 

--- a/tests/core/test_exception.py
+++ b/tests/core/test_exception.py
@@ -1,14 +1,14 @@
+from unittest.mock import patch
+
 import pytest
 
 from sqllineage import SQLPARSE_DIALECT
-
 from sqllineage.exceptions import (
     InvalidSyntaxException,
     SQLLineageException,
     UnsupportedStatementException,
 )
 from sqllineage.runner import LineageRunner
-from unittest.mock import patch
 
 
 def test_select_without_table():
@@ -55,10 +55,11 @@ SELECT * FROM bar""",
             dialect="tsql",
         )._eval()
 
-@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
+
+@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "true"})
 def test_user_warning_enable_tsql_no_semicolon_with_other_dialect():
     with pytest.warns(UserWarning):
-         LineageRunner(
+        LineageRunner(
             """SELECT * FROM foo;
 SELECT * FROM bar""",
         )._eval()

--- a/tests/core/test_exception.py
+++ b/tests/core/test_exception.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from sqllineage import SQLPARSE_DIALECT
@@ -56,10 +54,10 @@ SELECT * FROM bar""",
         )._eval()
 
 
-# @patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 def test_user_warning_enable_tsql_no_semicolon_with_other_dialect():
     with pytest.warns(UserWarning):
         LineageRunner(
             """SELECT * FROM foo;
 SELECT * FROM bar""",
-        tsql_no_semicolon=True)._eval()
+            tsql_no_semicolon=True,
+        )._eval()

--- a/tests/core/test_exception.py
+++ b/tests/core/test_exception.py
@@ -56,10 +56,10 @@ SELECT * FROM bar""",
         )._eval()
 
 
-@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
+# @patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 def test_user_warning_enable_tsql_no_semicolon_with_other_dialect():
     with pytest.warns(UserWarning):
         LineageRunner(
             """SELECT * FROM foo;
 SELECT * FROM bar""",
-        )._eval()
+        tsql_no_semicolon=True)._eval()

--- a/tests/core/test_exception.py
+++ b/tests/core/test_exception.py
@@ -1,12 +1,14 @@
 import pytest
 
 from sqllineage import SQLPARSE_DIALECT
+
 from sqllineage.exceptions import (
     InvalidSyntaxException,
     SQLLineageException,
     UnsupportedStatementException,
 )
 from sqllineage.runner import LineageRunner
+from unittest.mock import patch
 
 
 def test_select_without_table():
@@ -53,11 +55,10 @@ SELECT * FROM bar""",
             dialect="tsql",
         )._eval()
 
-
+@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 def test_user_warning_enable_tsql_no_semicolon_with_other_dialect():
     with pytest.warns(UserWarning):
-        LineageRunner(
+         LineageRunner(
             """SELECT * FROM foo;
 SELECT * FROM bar""",
-            tsql_no_semicolon=True,
         )._eval()

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -25,12 +25,3 @@ def test_silent_mode():
     sql = "begin; select * from dual;"
     LineageRunner(sql, dialect="greenplum", silent_mode=True)._eval()
 
-
-def test_default_schema():
-    sql = """insert into target_tab select user_id, user_name from source_tab_1, source_tab_2"""
-    assert_table_lineage_equal(
-        sql=sql,
-        source_tables={"ods.source_tab_1", "ods.source_tab_2"},
-        target_tables={"ods.target_tab"},
-        default_schema="ods",
-    )

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -1,4 +1,3 @@
-from sqllineage.core.models import SubQuery
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
 
@@ -25,9 +24,3 @@ def test_silent_mode():
     LineageRunner(sql, dialect="greenplum", silent_mode=True)._eval()
 
 
-def test_get_column_lineage_exclude_subquery_inpath():
-    v_sql = "insert into ta select b from (select b from tb union all select c from tc ) sub"
-    parse = LineageRunner(sql=v_sql)
-    for col_tuple in parse.get_column_lineage(exclude_subquery_columns=True):
-        for col in col_tuple:
-            assert not isinstance(col.parent, SubQuery)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -1,3 +1,5 @@
+from tests.helpers import assert_table_lineage_equal
+
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
 
@@ -24,3 +26,11 @@ def test_silent_mode():
     LineageRunner(sql, dialect="greenplum", silent_mode=True)._eval()
 
 
+def test_default_schema():
+    sql = """insert into target_tab select user_id, user_name from source_tab_1, source_tab_2"""
+    assert_table_lineage_equal(
+        sql=sql,
+        source_tables={"ods.source_tab_1", "ods.source_tab_2"},
+        target_tables={"ods.target_tab"},
+        default_schema="ods",
+    )

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -1,5 +1,3 @@
-from tests.helpers import assert_table_lineage_equal
-
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
 
@@ -24,4 +22,3 @@ def test_statements_trim_comment():
 def test_silent_mode():
     sql = "begin; select * from dual;"
     LineageRunner(sql, dialect="greenplum", silent_mode=True)._eval()
-

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,10 +60,14 @@ def assert_table_lineage_equal(
     dialect: str = "ansi",
     test_sqlfluff: bool = True,
     test_sqlparse: bool = True,
-    tsql_no_semicolon:bool =False
+    tsql_no_semicolon: bool = False,
 ):
-    lr = LineageRunner(sql, dialect=SQLPARSE_DIALECT,tsql_no_semicolon=tsql_no_semicolon)
-    lr_sqlfluff = LineageRunner(sql, dialect=dialect,tsql_no_semicolon=tsql_no_semicolon)
+    lr = LineageRunner(
+        sql, dialect=SQLPARSE_DIALECT, tsql_no_semicolon=tsql_no_semicolon
+    )
+    lr_sqlfluff = LineageRunner(
+        sql, dialect=dialect, tsql_no_semicolon=tsql_no_semicolon
+    )
     if test_sqlparse:
         _assert_table_lineage(lr, source_tables, target_tables)
     if test_sqlfluff:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,9 +60,10 @@ def assert_table_lineage_equal(
     dialect: str = "ansi",
     test_sqlfluff: bool = True,
     test_sqlparse: bool = True,
+    tsql_no_semicolon:bool =False
 ):
-    lr = LineageRunner(sql, dialect=SQLPARSE_DIALECT)
-    lr_sqlfluff = LineageRunner(sql, dialect=dialect)
+    lr = LineageRunner(sql, dialect=SQLPARSE_DIALECT,tsql_no_semicolon=tsql_no_semicolon)
+    lr_sqlfluff = LineageRunner(sql, dialect=dialect,tsql_no_semicolon=tsql_no_semicolon)
     if test_sqlparse:
         _assert_table_lineage(lr, source_tables, target_tables)
     if test_sqlfluff:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,12 +61,19 @@ def assert_table_lineage_equal(
     test_sqlfluff: bool = True,
     test_sqlparse: bool = True,
     tsql_no_semicolon: bool = False,
+    default_schema: Optional[str] = None,
 ):
     lr = LineageRunner(
-        sql, dialect=SQLPARSE_DIALECT, tsql_no_semicolon=tsql_no_semicolon
+        sql,
+        dialect=SQLPARSE_DIALECT,
+        tsql_no_semicolon=tsql_no_semicolon,
+        default_schema=default_schema,
     )
     lr_sqlfluff = LineageRunner(
-        sql, dialect=dialect, tsql_no_semicolon=tsql_no_semicolon
+        sql,
+        dialect=dialect,
+        tsql_no_semicolon=tsql_no_semicolon,
+        default_schema=default_schema,
     )
     if test_sqlparse:
         _assert_table_lineage(lr, source_tables, target_tables)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,20 +60,14 @@ def assert_table_lineage_equal(
     dialect: str = "ansi",
     test_sqlfluff: bool = True,
     test_sqlparse: bool = True,
-    tsql_no_semicolon: bool = False,
-    default_schema: Optional[str] = None,
 ):
     lr = LineageRunner(
         sql,
         dialect=SQLPARSE_DIALECT,
-        tsql_no_semicolon=tsql_no_semicolon,
-        default_schema=default_schema,
     )
     lr_sqlfluff = LineageRunner(
         sql,
         dialect=dialect,
-        tsql_no_semicolon=tsql_no_semicolon,
-        default_schema=default_schema,
     )
     if test_sqlparse:
         _assert_table_lineage(lr, source_tables, target_tables)

--- a/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
+++ b/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
@@ -1,11 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 
 from ....helpers import assert_table_lineage_equal
 
 
-# @patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 @pytest.mark.parametrize("dialect", ["tsql"])
 def test_tsql_multi_statement_no_semicolon(dialect: str):
     """
@@ -19,6 +16,5 @@ insert into tab2 select * from bar"""
         {"tab1", "tab2"},
         dialect=dialect,
         test_sqlparse=False,
-        tsql_no_semicolon=True
-
+        tsql_no_semicolon=True,
     )

--- a/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
+++ b/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
@@ -5,7 +5,7 @@ import pytest
 from ....helpers import assert_table_lineage_equal
 
 
-@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
+@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "true"})
 @pytest.mark.parametrize("dialect", ["tsql"])
 def test_tsql_multi_statement_no_semicolon(dialect: str):
     """

--- a/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
+++ b/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
@@ -5,7 +5,7 @@ import pytest
 from ....helpers import assert_table_lineage_equal
 
 
-@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
+# @patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 @pytest.mark.parametrize("dialect", ["tsql"])
 def test_tsql_multi_statement_no_semicolon(dialect: str):
     """
@@ -19,4 +19,6 @@ insert into tab2 select * from bar"""
         {"tab1", "tab2"},
         dialect=dialect,
         test_sqlparse=False,
+        tsql_no_semicolon=True
+
     )

--- a/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
+++ b/tests/sql/table/multiple_statements/test_tsql_no_semicolon.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
 import pytest
 
 from ....helpers import assert_table_lineage_equal
 
 
+@patch("os.environ", {"SQLLINEAGE_TSQL_NO_SEMICOLON": "TRUE"})
 @pytest.mark.parametrize("dialect", ["tsql"])
 def test_tsql_multi_statement_no_semicolon(dialect: str):
     """
@@ -16,5 +19,4 @@ insert into tab2 select * from bar"""
         {"tab1", "tab2"},
         dialect=dialect,
         test_sqlparse=False,
-        tsql_no_semicolon=True,
     )


### PR DESCRIPTION
Dear ALL：

目前模型的默认模式名是通过环境变量传递的，我认为实现方法不够python。
所以，我实现了另一种解决方法。 
1. 修改 sqllineage/config.py 实现配置项的读取和写入， 读取方法保持和已有方法兼容。
2. 修改 sqllineage/core/models.py 的Schema 类，在每次初始化的时候动态读取配置
3. 修改 sqllineage/runner.py的init方法，传入变量，并在 SQLLineageConfig 赋值
请大家提出意见，谢谢

Currently the default schema name of the model is passed through environment variables, and I think the implementation method is not python enough.
So, I implemented another workaround.
1. Modify sqllineage/config.py to implement reading and writing of configuration items. The reading method remains compatible with the existing method.
2. Modify the Schema class of sqllineage/core/models.py and dynamically read the configuration every time it is initialized.
3. Modify the init method of sqllineage/runner.py, pass in variables, and assign values in SQLLineageConfig
Please give your opinions, thank you
