### PR TITLE
fix: SQLLineageConfig boolean value returns True for all non-empty strings (#551)

### DIFF
--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -15,14 +15,39 @@ class _SQLLineageConfigLoader:
         # to enable tsql no semicolon splitter mode
         "TSQL_NO_SEMICOLON": (bool, False),
     }
+    BOOLEAN_TRUE_STRINGS = ("true", "on", "ok", "y", "yes", "1")
 
     def __getattr__(self, item):
         if item in self.config:
             type_, default = self.config[item]
             # require SQLLINEAGE_ prefix from environment variable
-            return type_(os.environ.get("SQLLINEAGE_" + item, default))
+            return self.parse_value(
+                os.environ.get("SQLLINEAGE_" + item, default), type_
+            )
         else:
             return super().__getattribute__(item)
+
+    @classmethod
+    def parse_value(cls, value, cast):
+        """Parse and cast provided value
+
+        :param value: Stringed value.
+        :param cast: Type to cast return value as.
+
+        :returns: Casted value
+        """
+        if cast is None:
+            return value
+
+        if cast is bool:
+            try:
+                value = int(value) != 0
+            except ValueError:
+                value = value.lower().strip() in cls.BOOLEAN_TRUE_STRINGS
+        else:
+            value = cast(value)
+
+        return value
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -36,9 +36,6 @@ class _SQLLineageConfigLoader:
 
         :returns: Casted value
         """
-        if cast is None:
-            return value
-
         if cast is bool:
             try:
                 value = int(value) != 0

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -21,9 +21,3 @@ def test_config():
 
     assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
     assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
-
-
-def test_config_parse_value_with_cast_none():
-    parse_value_str = SQLLineageConfig.parse_value("str", None)
-    assert type(parse_value_str) is str
-    assert parse_value_str == "str"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import os
+from unittest.mock import patch
+
+from sqllineage.config import SQLLineageConfig
+
+
+@patch(
+    "os.environ",
+    {
+        "SQLLINEAGE_DIRECTORY": os.path.join(os.path.dirname(__file__), "data"),
+        "SQLLINEAGE_DEFAULT_SCHEMA": "<default>",
+        "SQLLINEAGE_TSQL_NO_SEMICOLON": "true",
+    },
+)
+def test_config():
+    assert type(SQLLineageConfig.DIRECTORY) is str
+    assert SQLLineageConfig.DIRECTORY == os.path.join(os.path.dirname(__file__), "data")
+
+    assert type(SQLLineageConfig.DEFAULT_SCHEMA) is str
+    assert SQLLineageConfig.DEFAULT_SCHEMA == "<default>"
+
+    assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
+    assert SQLLineageConfig.TSQL_NO_SEMICOLON is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,3 +21,9 @@ def test_config():
 
     assert type(SQLLineageConfig.TSQL_NO_SEMICOLON) is bool
     assert SQLLineageConfig.TSQL_NO_SEMICOLON is True
+
+
+def test_config_parse_value_with_cast_none():
+    parse_value_str = SQLLineageConfig.parse_value("str", None)
+    assert type(parse_value_str) is str
+    assert parse_value_str == "str"


### PR DESCRIPTION
fix: SQLLineageConfig returns True for all non-empty strings (#551)

Closes #551 