### PR TITLE
fix: Set param from config

### DIFF
--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -30,7 +30,9 @@ class _SQLLineageConfigLoader:
 
     def __getattr__(self, item: str):
         if item in self.config.keys():
-            if value := self._thread_config.get(self.get_ident(), {}).get(item, None):
+            if (
+                value := self._thread_config.get(self.get_ident(), {}).get(item)
+            ) is not None:
                 return value
 
             type_, default = self.config[item]
@@ -81,14 +83,13 @@ class _SQLLineageConfigLoader:
                     value, self.config[key][0]
                 )
             else:
-                super().__setattr__(key, value)
+                raise ConfigException(f"Invalid config key: {key}")
         return self
 
     def __enter__(self):
         if self._in_context_manager:
             raise ConfigException("SQLLineageConfig context manager is not reentrant")
         self._in_context_manager = True
-        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.get_ident() in self._thread_config:

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -1,10 +1,14 @@
 import os
+import threading
+from typing import Any, Dict
 
 
 class _SQLLineageConfigLoader:
     """
     Load all configurable items from environment variable, otherwise fallback to default
     """
+
+    _thread_config: Dict[int, Dict[str, Any]] = {}
 
     # inspired by https://github.com/joke2k/django-environ
     config = {
@@ -19,8 +23,11 @@ class _SQLLineageConfigLoader:
     }
     BOOLEAN_TRUE_STRINGS = ("true", "on", "ok", "y", "yes", "1")
 
-    def __getattr__(self, item):
-        if item in self.config:
+    def __getattr__(self, item: str):
+        if item in self.config.keys():
+            if value := self._thread_config.get(self.get_ident(), {}).get(item, None):
+                return value
+
             type_, default = self.config[item]
             # require SQLLINEAGE_ prefix from environment variable
             return self.parse_value(
@@ -30,7 +37,11 @@ class _SQLLineageConfigLoader:
             return super().__getattribute__(item)
 
     @classmethod
-    def parse_value(cls, value, cast):
+    def get_ident(cls) -> int:
+        return threading.get_ident()
+
+    @classmethod
+    def parse_value(cls, value, cast) -> Any:
         """Parse and cast provided value
 
         :param value: Stringed value.
@@ -47,6 +58,25 @@ class _SQLLineageConfigLoader:
             value = cast(value)
 
         return value
+
+    def set(self, **kwargs):
+        self.__enter__()
+        for key, value in kwargs.items():
+            if key in self.config.keys():
+                self._thread_config[self.get_ident()][key] = self.parse_value(
+                    value, self.config[key][0]
+                )
+            else:
+                super().__setattr__(key, value)
+        return self
+
+    def __enter__(self):
+        if self.get_ident() not in self._thread_config.keys():
+            self._thread_config[self.get_ident()] = {}
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.get_ident() in self._thread_config.keys():
+            self._thread_config.pop(self.get_ident())
 
 
 SQLLineageConfig = _SQLLineageConfigLoader()

--- a/sqllineage/exceptions.py
+++ b/sqllineage/exceptions.py
@@ -12,3 +12,7 @@ class InvalidSyntaxException(SQLLineageException):
 
 class MetaDataProviderException(SQLLineageException):
     """Raised for MetaDataProvider errors"""
+
+
+class ConfigException(SQLLineageException):
+    """Raised for configuration errors"""

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -34,20 +34,30 @@ def test_disable_direct_update_config():
 
 
 def test_update_config_using_context_manager():
-    with SQLLineageConfig(LATERAL_COLUMN_ALIAS_REFERENCE=True) as config:
-        assert config.LATERAL_COLUMN_ALIAS_REFERENCE is True
+    with SQLLineageConfig(LATERAL_COLUMN_ALIAS_REFERENCE=True):
+        assert SQLLineageConfig.LATERAL_COLUMN_ALIAS_REFERENCE is True
     assert SQLLineageConfig.LATERAL_COLUMN_ALIAS_REFERENCE is False
 
-    with SQLLineageConfig(DEFAULT_SCHEMA="ods") as config:
-        assert config.DEFAULT_SCHEMA == "ods"
+    with SQLLineageConfig(DEFAULT_SCHEMA="ods"):
+        assert SQLLineageConfig.DEFAULT_SCHEMA == "ods"
     assert SQLLineageConfig.DEFAULT_SCHEMA == ""
+
+    with SQLLineageConfig(DIRECTORY=""):
+        assert SQLLineageConfig.DIRECTORY == ""
+    assert SQLLineageConfig.DIRECTORY != ""
 
 
 def test_update_config_context_manager_non_reentrant():
-    with SQLLineageConfig(DEFAULT_SCHEMA="ods"):
-        with pytest.raises(ConfigException):
+    with pytest.raises(ConfigException):
+        with SQLLineageConfig(DEFAULT_SCHEMA="ods"):
             with SQLLineageConfig(DEFAULT_SCHEMA="dwd"):
                 pass
+
+
+def test_disable_update_unknown_config():
+    with pytest.raises(ConfigException):
+        with SQLLineageConfig(UNKNOWN_KEY="value"):
+            pass
 
 
 schema_list = ("stg", "ods", "dwd", "dw", "dwa", "dwv")
@@ -72,8 +82,3 @@ def test_config_proecess():
         for work_result in p.imap_unordered(check_schema, schema_list):
             target, source = work_result
             assert target == source
-
-
-def test_config_other():
-    with SQLLineageConfig(other="xxx"):
-        assert SQLLineageConfig.other == "xxx"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -43,6 +43,13 @@ def test_update_config_using_context_manager():
     assert SQLLineageConfig.DEFAULT_SCHEMA == ""
 
 
+def test_update_config_context_manager_non_reentrant():
+    with SQLLineageConfig(DEFAULT_SCHEMA="ods"):
+        with pytest.raises(ConfigException):
+            with SQLLineageConfig(DEFAULT_SCHEMA="dwd"):
+                pass
+
+
 schema_list = ("stg", "ods", "dwd", "dw", "dwa", "dwv")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 [flake8]
 exclude = .tox,.git,__pycache__,build,sqllineagejs,venv,env
 max-line-length = 120
-# ignore = D100,D101
+ignore = A005,W503
 show-source = true
 enable-extensions=G
 application-import-names = sqllineage


### PR DESCRIPTION
Dear ALL：

目前模型的默认模式名是通过环境变量传递的，我认为实现方法不够python。
所以，我实现了另一种解决方法。

修改 sqllineage/config.py 实现配置项的读取和写入， 读取方法保持和已有方法兼容。
修改 sqllineage/core/models.py 的Schema 类，在每次初始化的时候动态读取配置
修改 sqllineage/runner.py的init方法，传入变量，并在 SQLLineageConfig 赋值
请大家提出意见，谢谢
Currently the default schema name of the model is passed through environment variables, and I think the implementation method is not python enough.
So, I implemented another workaround.

Modify sqllineage/config.py to implement reading and writing of configuration items. The reading method remains compatible with the existing method.
Modify the Schema class of sqllineage/core/models.py and dynamically read the configuration every time it is initialized.
Modify the init method of sqllineage/runner.py, pass in variables, and assign values in SQLLineageConfig
Please give your opinions, thank you



重新建立分支并提交
Re-branch and submit

first step to solve #536 