### PR TITLE
feat: set target table's column using metadata

### DIFF
--- a/sqllineage/core/parser/__init__.py
+++ b/sqllineage/core/parser/__init__.py
@@ -76,6 +76,6 @@ class SourceHandlerMixin:
                             SQLLineageConfig.LATERAL_COLUMN_ALIAS_REFERENCE
                             and tgt_col_from_query.from_alias
                         ):
-                            lateral_column_aliases[tgt_col_from_query.raw_name] = (
-                                src_cols_resolved
-                            )
+                            lateral_column_aliases[
+                                tgt_col_from_query.raw_name
+                            ] = src_cols_resolved

--- a/sqllineage/core/parser/__init__.py
+++ b/sqllineage/core/parser/__init__.py
@@ -76,6 +76,6 @@ class SourceHandlerMixin:
                             SQLLineageConfig.LATERAL_COLUMN_ALIAS_REFERENCE
                             and tgt_col_from_query.from_alias
                         ):
-                            lateral_column_aliases[
-                                tgt_col_from_query.raw_name
-                            ] = src_cols_resolved
+                            lateral_column_aliases[tgt_col_from_query.raw_name] = (
+                                src_cols_resolved
+                            )

--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -1,14 +1,14 @@
 from sqlfluff.core.parser import BaseSegment
 
 from sqllineage.core.holders import SubQueryLineageHolder
-from sqllineage.core.models import Path
+from sqllineage.core.models import Column, Path, Table
 from sqllineage.core.parser.sqlfluff.extractors.base import BaseExtractor
 from sqllineage.core.parser.sqlfluff.extractors.select import SelectExtractor
 from sqllineage.core.parser.sqlfluff.models import SqlFluffColumn, SqlFluffTable
 from sqllineage.core.parser.sqlfluff.utils import (
     list_child_segments,
 )
-from sqllineage.utils.entities import AnalyzerContext
+from sqllineage.utils.entities import AnalyzerContext, ColumnQualifierTuple
 from sqllineage.utils.helpers import escape_identifier_name
 
 
@@ -32,7 +32,8 @@ class CreateInsertExtractor(BaseExtractor):
     ) -> SubQueryLineageHolder:
         holder = self._init_holder(context)
         src_flag = tgt_flag = False
-        for segment in list_child_segments(statement):
+        statement_child = list_child_segments(statement)
+        for seg_idx, segment in enumerate(list_child_segments(statement)):
             if segment.type == "with_compound_statement":
                 holder |= self.delegate_to_cte(segment, holder)
             elif segment.type == "bracketed" and any(
@@ -111,6 +112,34 @@ class CreateInsertExtractor(BaseExtractor):
                     else:
                         holder.add_write(Path(escape_identifier_name(segment.raw)))
                 tgt_flag = False
+
+                if statement.type == "insert_statement" and holder.write:
+                    sub_segments = list_child_segments(
+                        segment=statement_child[seg_idx + 1]
+                    )
+                    if not all(
+                        sub_segment.type in ["column_reference", "column_definition"]
+                        for sub_segment in sub_segments
+                    ):
+                        tgt_tab = list(holder.write)[0]
+                        if isinstance(tgt_tab, Table) and tgt_tab.schema:
+                            col_list = [
+                                Column(
+                                    name=col.raw_name,
+                                    source_columns=[
+                                        ColumnQualifierTuple(
+                                            column=col.raw_name, qualifier=None
+                                        )
+                                    ],
+                                )
+                                for col in self.metadata_provider.get_table_columns(
+                                    table=Table(
+                                        name=tgt_tab.raw_name,
+                                        schema=tgt_tab.schema.raw_name,
+                                    )
+                                )
+                            ]
+                            holder.add_write_column(*col_list)
             if src_flag:
                 if segment.type in ["table_reference", "object_reference"]:
                     holder.add_read(SqlFluffTable.of(segment))

--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -1,14 +1,14 @@
 from sqlfluff.core.parser import BaseSegment
 
 from sqllineage.core.holders import SubQueryLineageHolder
-from sqllineage.core.models import Column, Path, Table
+from sqllineage.core.models import Path, Table
 from sqllineage.core.parser.sqlfluff.extractors.base import BaseExtractor
 from sqllineage.core.parser.sqlfluff.extractors.select import SelectExtractor
 from sqllineage.core.parser.sqlfluff.models import SqlFluffColumn, SqlFluffTable
 from sqllineage.core.parser.sqlfluff.utils import (
     list_child_segments,
 )
-from sqllineage.utils.entities import AnalyzerContext, ColumnQualifierTuple
+from sqllineage.utils.entities import AnalyzerContext
 from sqllineage.utils.helpers import escape_identifier_name
 
 
@@ -32,8 +32,7 @@ class CreateInsertExtractor(BaseExtractor):
     ) -> SubQueryLineageHolder:
         holder = self._init_holder(context)
         src_flag = tgt_flag = False
-        statement_child = list_child_segments(statement)
-        for seg_idx, segment in enumerate(list_child_segments(statement)):
+        for segment in list_child_segments(statement):
             if segment.type == "with_compound_statement":
                 holder |= self.delegate_to_cte(segment, holder)
             elif segment.type == "bracketed" and any(
@@ -105,6 +104,15 @@ class CreateInsertExtractor(BaseExtractor):
                 if segment.type in ["table_reference", "object_reference"]:
                     write_obj = SqlFluffTable.of(segment)
                     holder.add_write(write_obj)
+                    # get target table columns from metadata if available
+                    if (
+                        isinstance(write_obj, Table)
+                        and self.metadata_provider
+                        and statement.type == "insert_statement"
+                    ):
+                        holder.add_write_column(
+                            *self.metadata_provider.get_table_columns(table=write_obj)
+                        )
                 elif segment.type == "literal":
                     if segment.raw.isnumeric():
                         # Special Handling for Spark Bucket Table DDL
@@ -112,31 +120,6 @@ class CreateInsertExtractor(BaseExtractor):
                     else:
                         holder.add_write(Path(escape_identifier_name(segment.raw)))
                 tgt_flag = False
-
-                if statement.type == "insert_statement" and holder.write:
-                    sub_segments = list_child_segments(
-                        segment=statement_child[seg_idx + 1]
-                    )
-                    if not all(
-                        sub_segment.type in ["column_reference", "column_definition"]
-                        for sub_segment in sub_segments
-                    ):
-                        tgt_tab = list(holder.write)[0]
-                        if isinstance(tgt_tab, Table) and tgt_tab.schema:
-                            col_list = [
-                                Column(
-                                    name=col.raw_name,
-                                    source_columns=[
-                                        ColumnQualifierTuple(
-                                            column=col.raw_name, qualifier=None
-                                        )
-                                    ],
-                                )
-                                for col in self.metadata_provider.get_table_columns(
-                                    table=tgt_tab
-                                )
-                            ]
-                            holder.add_write_column(*col_list)
             if src_flag:
                 if segment.type in ["table_reference", "object_reference"]:
                     holder.add_read(SqlFluffTable.of(segment))

--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -133,10 +133,7 @@ class CreateInsertExtractor(BaseExtractor):
                                     ],
                                 )
                                 for col in self.metadata_provider.get_table_columns(
-                                    table=Table(
-                                        name=tgt_tab.raw_name,
-                                        schema=tgt_tab.schema.raw_name,
-                                    )
+                                    table=tgt_tab
                                 )
                             ]
                             holder.add_write_column(*col_list)

--- a/tests/sql/column/test_metadata_target_column.py
+++ b/tests/sql/column/test_metadata_target_column.py
@@ -1,0 +1,119 @@
+from typing import Dict, List, Optional
+
+from sqllineage.core.metadata_provider import MetaDataProvider
+from sqllineage.utils.entities import ColumnQualifierTuple
+from ...helpers import assert_column_lineage_equal
+
+
+class MetaCollect(MetaDataProvider):
+    def __init__(self, metadata: Optional[Dict[str, List[str]]]):
+        super().__init__()
+        self.metadata = metadata if metadata else {}
+
+    def _get_table_columns(self, schema: str, table: str, **kwargs) -> List[str]:
+        return self.metadata.get(f"{schema}.{table}", [])
+
+
+meta_collect = {
+    "ods.source_a": ["day_id", "user_id", "user_name"],
+    "ods.target_tab": ["day_no", "user_code", "name"],
+}
+
+
+def test_metadata_target_column():
+    sql = """insert into ods.target_tab select day_id as acct_id, user_id as xxx, user_name as yyy from ods.source_a"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte():
+    sql = """
+INSERT INTO ods.target_tab
+WITH cte1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+SELECT acct_id, xxx, yyy FROM cte1"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte2():
+    sql = """INSERT INTO ods.target_tab
+    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+    SELECT acct_id, xxx, yyy FROM tab1)"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )
+
+
+def test_metadata_target_column_cte3():
+    sql = """ INSERT INTO ods.target_tab
+    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
+    SELECT acct_id, xxx, yyy FROM tab1);"""
+    assert_column_lineage_equal(
+        sql=sql,
+        column_lineages=[
+            (
+                ColumnQualifierTuple("user_name", "ods.source_a"),
+                ColumnQualifierTuple("name", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_no", "ods.target_tab"),
+            ),
+            (
+                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_code", "ods.target_tab"),
+            ),
+        ],
+        metadata_provider=MetaCollect(meta_collect),
+        test_sqlparse=False,
+    )

--- a/tests/sql/column/test_metadata_target_column.py
+++ b/tests/sql/column/test_metadata_target_column.py
@@ -15,26 +15,26 @@ class MetaCollect(MetaDataProvider):
 
 
 meta_collect = {
-    "ods.source_a": ["day_id", "user_id", "user_name"],
-    "ods.target_tab": ["day_no", "user_code", "name"],
+    "ods.source_tab": ["day_id", "user_id", "name"],
+    "ods.target_tab": ["day_no", "user_code", "user_name"],
 }
 
 
 def test_metadata_target_column():
-    sql = """insert into ods.target_tab select day_id as acct_id, user_id as xxx, user_name as yyy from ods.source_a"""
+    sql = """insert into ods.target_tab select day_id as acct_id, user_id as xxx, name as yyy from ods.source_tab"""
     assert_column_lineage_equal(
         sql=sql,
         column_lineages=[
             (
-                ColumnQualifierTuple("user_name", "ods.source_a"),
-                ColumnQualifierTuple("name", "ods.target_tab"),
+                ColumnQualifierTuple("name", "ods.source_tab"),
+                ColumnQualifierTuple("user_name", "ods.target_tab"),
             ),
             (
-                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_id", "ods.source_tab"),
                 ColumnQualifierTuple("day_no", "ods.target_tab"),
             ),
             (
-                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_id", "ods.source_tab"),
                 ColumnQualifierTuple("user_code", "ods.target_tab"),
             ),
         ],
@@ -46,72 +46,22 @@ def test_metadata_target_column():
 def test_metadata_target_column_cte():
     sql = """
 INSERT INTO ods.target_tab
-WITH cte1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
-SELECT acct_id, xxx, yyy FROM cte1"""
+WITH cte_table AS (SELECT day_id as acct_id, user_id as xxx, name as yyy FROM ods.source_tab)
+SELECT acct_id, xxx, yyy FROM cte_table"""
     assert_column_lineage_equal(
         sql=sql,
         column_lineages=[
             (
-                ColumnQualifierTuple("user_id", "ods.source_a"),
+                ColumnQualifierTuple("user_id", "ods.source_tab"),
                 ColumnQualifierTuple("user_code", "ods.target_tab"),
             ),
             (
-                ColumnQualifierTuple("day_id", "ods.source_a"),
+                ColumnQualifierTuple("day_id", "ods.source_tab"),
                 ColumnQualifierTuple("day_no", "ods.target_tab"),
             ),
             (
-                ColumnQualifierTuple("user_name", "ods.source_a"),
-                ColumnQualifierTuple("name", "ods.target_tab"),
-            ),
-        ],
-        metadata_provider=MetaCollect(meta_collect),
-        test_sqlparse=False,
-    )
-
-
-def test_metadata_target_column_cte2():
-    sql = """INSERT INTO ods.target_tab
-    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
-    SELECT acct_id, xxx, yyy FROM tab1)"""
-    assert_column_lineage_equal(
-        sql=sql,
-        column_lineages=[
-            (
-                ColumnQualifierTuple("user_name", "ods.source_a"),
-                ColumnQualifierTuple("name", "ods.target_tab"),
-            ),
-            (
-                ColumnQualifierTuple("day_id", "ods.source_a"),
-                ColumnQualifierTuple("day_no", "ods.target_tab"),
-            ),
-            (
-                ColumnQualifierTuple("user_id", "ods.source_a"),
-                ColumnQualifierTuple("user_code", "ods.target_tab"),
-            ),
-        ],
-        metadata_provider=MetaCollect(meta_collect),
-        test_sqlparse=False,
-    )
-
-
-def test_metadata_target_column_cte3():
-    sql = """ INSERT INTO ods.target_tab
-    (WITH tab1 AS (SELECT day_id as acct_id, user_id as xxx, user_name as yyy FROM ods.source_a)
-    SELECT acct_id, xxx, yyy FROM tab1);"""
-    assert_column_lineage_equal(
-        sql=sql,
-        column_lineages=[
-            (
-                ColumnQualifierTuple("user_name", "ods.source_a"),
-                ColumnQualifierTuple("name", "ods.target_tab"),
-            ),
-            (
-                ColumnQualifierTuple("day_id", "ods.source_a"),
-                ColumnQualifierTuple("day_no", "ods.target_tab"),
-            ),
-            (
-                ColumnQualifierTuple("user_id", "ods.source_a"),
-                ColumnQualifierTuple("user_code", "ods.target_tab"),
+                ColumnQualifierTuple("name", "ods.source_tab"),
+                ColumnQualifierTuple("user_name", "ods.target_tab"),
             ),
         ],
         metadata_provider=MetaCollect(meta_collect),


### PR DESCRIPTION
The local git branch has been corrupted, so new pull 

```sql
insert into targat select  a, b, c from source
```
old result:
source.a -> target.a
source.b -> target.b
source.c -> target.c

Get the actual column name of target table through metadata (example: a1,b1,c1):
new result:
source.a -> target.a1
source.b -> target.b1
source.c -> target.c1


Closes #528