### PR TITLE
fix: allow tsql identifier enclosed in brackets

### DIFF
--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -17,6 +17,10 @@ def escape_identifier_name(name: str):
         for quote_char in quote_chars:
             name = name.strip(quote_char)
         return name
+    elif name.startswith("[") and name.endswith("]"):
+        # tsql allows quoted identifier with square brackets, see reference
+        # https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16#classes-of-identifiers
+        return name.strip("[]")
     else:
         return name.lower()
 

--- a/tests/sql/table/test_select_dialect_specific.py
+++ b/tests/sql/table/test_select_dialect_specific.py
@@ -24,6 +24,18 @@ def test_select_with_schema_in_backtick(dialect: str):
     )
 
 
+@pytest.mark.parametrize("dialect", ["tsql"])
+def test_select_with_table_name_in_bracket(dialect: str):
+    assert_table_lineage_equal("SELECT * FROM [tab1]", {"tab1"}, dialect=dialect)
+
+
+@pytest.mark.parametrize("dialect", ["tsql"])
+def test_select_with_schema_in_bracket(dialect: str):
+    assert_table_lineage_equal(
+        "SELECT * FROM [schema1].[tab1]", {"schema1.tab1"}, dialect=dialect
+    )
+
+
 @pytest.mark.parametrize("dialect", ["databricks", "hive", "sparksql"])
 def test_select_left_semi_join(dialect: str):
     assert_table_lineage_equal(


### PR DESCRIPTION
Closes #583 