### PR TITLE
add del lineage which is table and table name contain tmp or temp 

### DIFF
--- a/sqllineage/core/metadata_provider.py
+++ b/sqllineage/core/metadata_provider.py
@@ -60,6 +60,17 @@ class MetaDataProvider:
         bool value tells whether this provider is ready to provide metadata
         """
         return True
+        
+    @classmethod
+    def str2enum(cls, name):
+        if name == "lineage":
+            return EdgeType.LINEAGE
+        if name == "rename":
+            return EdgeType.RENAME
+        if name == "has_column":
+            return EdgeType.HAS_COLUMN
+        if name == "has_alias":
+            return EdgeType.HAS_ALIAS
 
 
 class MetaDataSession:


### PR DESCRIPTION
Whether we try to delete some intermediate tables. Deletion using regular matching, such as tables starting with ^tmp can be deleted in the blood relationship. The upstream and downstream of tables starting with ^tmp can be directly connected according to the Cartesian product.

![1234](https://github.com/reata/sqllineage/assets/141558247/74b25c0f-8a5e-40fd-aac7-e7c9b1a2570b)
