### PR TITLE
delete some intermediate tables

### DIFF
--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -379,6 +379,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         metadata_provider: MetaDataProvider, *args: StatementLineageHolder
     ) -> DiGraph:
         g = DiGraph()
+        g1 = DiGraph()
         for holder in args:
             g = nx.compose(g, holder.graph)
             if holder.drop:

--- a/sqllineage/core/metadata_provider.py
+++ b/sqllineage/core/metadata_provider.py
@@ -60,6 +60,17 @@ class MetaDataProvider:
         bool value tells whether this provider is ready to provide metadata
         """
         return True
+        
+    @classmethod
+    def str2enum(cls, name):
+        if name == "lineage":
+            return EdgeType.LINEAGE
+        if name == "rename":
+            return EdgeType.RENAME
+        if name == "has_column":
+            return EdgeType.HAS_COLUMN
+        if name == "has_alias":
+            return EdgeType.HAS_ALIAS
 
 
 class MetaDataSession:


### PR DESCRIPTION
Whether we try to delete some intermediate tables. Deletion using regular matching, such as tables starting with ^tmp can be deleted in the blood relationship. The upstream and downstream of tables starting with ^tmp can be directly connected according to the Cartesian product.


![1234](https://github.com/reata/sqllineage/assets/141558247/7586875b-6b34-4f4d-8ccb-595249adff33)

