### PR TITLE
Fix sqllineage to read nested sqlfluff config files.

### DIFF
--- a/sqllineage/cli.py
+++ b/sqllineage/cli.py
@@ -16,7 +16,7 @@ from sqllineage.core.metadata.sqlalchemy import SQLAlchemyMetaDataProvider
 from sqllineage.drawing import draw_lineage_graph
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
-from sqllineage.utils.helpers import extract_sql_from_args
+from sqllineage.utils.helpers import extract_sql_from_args, extract_file_path_from_args
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,8 @@ def main(args=None) -> None:
     if args.e and args.f:
         warnings.warn("Both -e and -f options are specified. -e option will be ignored")
     if args.f or args.e:
-        sql, file_path = extract_sql_from_args(args)
+        sql = extract_sql_from_args(args)
+        file_path = extract_file_path_from_args(args)
         runner = LineageRunner(
             sql,
             file_path=file_path,

--- a/sqllineage/cli.py
+++ b/sqllineage/cli.py
@@ -107,9 +107,10 @@ def main(args=None) -> None:
     if args.e and args.f:
         warnings.warn("Both -e and -f options are specified. -e option will be ignored")
     if args.f or args.e:
-        sql = extract_sql_from_args(args)
+        sql, file_path = extract_sql_from_args(args)
         runner = LineageRunner(
             sql,
+            file_path=file_path,
             dialect=args.dialect,
             metadata_provider=metadata_provider,
             verbose=args.verbose,

--- a/sqllineage/cli.py
+++ b/sqllineage/cli.py
@@ -16,7 +16,7 @@ from sqllineage.core.metadata.sqlalchemy import SQLAlchemyMetaDataProvider
 from sqllineage.drawing import draw_lineage_graph
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
-from sqllineage.utils.helpers import extract_sql_from_args, extract_file_path_from_args
+from sqllineage.utils.helpers import extract_file_path_from_args, extract_sql_from_args
 
 logger = logging.getLogger(__name__)
 

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -37,22 +37,22 @@ class LineageRunner(object):
     def __init__(
         self,
         sql: str,
-        file_path: str = ".",
         dialect: str = DEFAULT_DIALECT,
         metadata_provider: MetaDataProvider = DummyMetaDataProvider(),
         verbose: bool = False,
         silent_mode: bool = False,
         draw_options: Optional[Dict[str, Any]] = None,
+        file_path: str = ".",
     ):
         """
         The entry point of SQLLineage after command line options are parsed.
 
         :param sql: a string representation of SQL statements.
-        :param file_path: path of the SQL file.
         :param dialect: sql dialect
         :param metadata_provider: metadata service object providing table schema
         :param verbose: verbose flag indicating whether statement-wise lineage result will be shown
         :param silent_mode: boolean flag indicating whether to skip lineage analysis for unknown statement types
+        :param file_path: path of the SQL file.
         """
         if dialect == SQLPARSE_DIALECT:
             warnings.warn(

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -37,6 +37,7 @@ class LineageRunner(object):
     def __init__(
         self,
         sql: str,
+        file_path: str = ".",
         dialect: str = DEFAULT_DIALECT,
         metadata_provider: MetaDataProvider = DummyMetaDataProvider(),
         verbose: bool = False,
@@ -47,6 +48,7 @@ class LineageRunner(object):
         The entry point of SQLLineage after command line options are parsed.
 
         :param sql: a string representation of SQL statements.
+        :param file_path: path of the SQL file.
         :param dialect: sql dialect
         :param metadata_provider: metadata service object providing table schema
         :param verbose: verbose flag indicating whether statement-wise lineage result will be shown
@@ -60,6 +62,7 @@ class LineageRunner(object):
                 stacklevel=2,
             )
         self._sql = sql
+        self._file_path = file_path
         self._verbose = verbose
         self._draw_options = draw_options if draw_options else {}
         self._evaluated = False
@@ -183,7 +186,9 @@ Target Tables:
         analyzer = (
             SqlParseLineageAnalyzer()
             if self._dialect == SQLPARSE_DIALECT
-            else SqlFluffLineageAnalyzer(self._dialect, self._silent_mode)
+            else SqlFluffLineageAnalyzer(
+                self._file_path, self._dialect, self._silent_mode
+            )
         )
         if SQLLineageConfig.TSQL_NO_SEMICOLON and self._dialect == "tsql":
             self._stmt = analyzer.split_tsql(self._sql.strip())

--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -1,6 +1,6 @@
 import logging
 from argparse import Namespace
-from typing import List, Tuple
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +25,11 @@ def escape_identifier_name(name: str):
         return name.lower()
 
 
-def extract_sql_from_args(args: Namespace) -> Tuple[str, str]:
+def extract_sql_from_args(args: Namespace) -> str:
     sql = ""
-    file_path = "."
     if getattr(args, "f", None):
         try:
             with open(args.f) as f:
-                file_path = args.f
                 sql = f.read()
         except IsADirectoryError:
             logger.exception("%s is a directory", args.f)
@@ -45,7 +43,14 @@ def extract_sql_from_args(args: Namespace) -> Tuple[str, str]:
             exit(1)
     elif getattr(args, "e", None):
         sql = args.e
-    return sql, file_path
+    return sql
+
+
+def extract_file_path_from_args(args: Namespace) -> str:
+    file_path = "."
+    if getattr(args, "f", None):
+        file_path = args.f
+    return file_path
 
 
 def split(sql: str) -> List[str]:

--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -1,6 +1,6 @@
 import logging
 from argparse import Namespace
-from typing import List
+from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +25,13 @@ def escape_identifier_name(name: str):
         return name.lower()
 
 
-def extract_sql_from_args(args: Namespace) -> str:
+def extract_sql_from_args(args: Namespace) -> Tuple[str, str]:
     sql = ""
+    file_path = "."
     if getattr(args, "f", None):
         try:
             with open(args.f) as f:
+                file_path = args.f
                 sql = f.read()
         except IsADirectoryError:
             logger.exception("%s is a directory", args.f)
@@ -43,7 +45,7 @@ def extract_sql_from_args(args: Namespace) -> str:
             exit(1)
     elif getattr(args, "e", None):
         sql = args.e
-    return sql
+    return sql, file_path
 
 
 def split(sql: str) -> List[str]:


### PR DESCRIPTION
Closes #628 
The added code is not changing any logic, it only alows sqlfluff use the max power of nested configs.
By default `file_path` is `'.'` . That's the same for `FluffConfig.from_root`, so I hope all right.

P.s. That's my first PR, so I ask you not to be so rude and I open for your comments.