### PR TITLE
feat: upgrade sqlfluff to 3.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "sqlparse==0.5.0",
         "networkx>=2.4",
-        "sqlfluff~=3.2.5",
+        "sqlfluff==3.3.0",
         "sqlalchemy>=2.0.0",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "sqlparse==0.5.0",
         "networkx>=2.4",
-        "sqlfluff==3.0.5",
+        "sqlfluff~=3.2.5",
         "sqlalchemy>=2.0.0",
     ],
     entry_points={"console_scripts": ["sqllineage = sqllineage.cli:main"]},

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -137,9 +137,6 @@ class SubQueryLineageHolder(ColumnLineageMixin):
             tgt_tbl = list(self.write)[0]
             for idx, tgt_col in enumerate(tgt_cols):
                 tgt_col.parent = tgt_tbl
-                if tgt_col in self.write_columns:
-                    # for DDL with PARTITIONED BY (col) or CLUSTERED BY (col), column can be added multiple times
-                    break
                 self.graph.add_edge(
                     tgt_tbl, tgt_col, type=EdgeType.HAS_COLUMN, **{EdgeTag.INDEX: idx}
                 )

--- a/sqllineage/core/parser/sqlfluff/extractors/select.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/select.py
@@ -101,7 +101,8 @@ class SelectExtractor(BaseExtractor, SourceHandlerMixin):
                         function.first_non_whitespace_segment_raw_upper
                         == "SWAP_PARTITIONS_BETWEEN_TABLES"
                     ):
-                        if bracketed := function.get_child("bracketed"):
+                        if function_contents := function.get_child("function_contents"):
+                            bracketed = function_contents.segments[0]
                             expressions = bracketed.get_children("expression")
                             holder.add_read(
                                 SqlFluffTable(

--- a/sqllineage/core/parser/sqlfluff/models.py
+++ b/sqllineage/core/parser/sqlfluff/models.py
@@ -223,12 +223,6 @@ class SqlFluffColumn(Column):
         columns = []
         sub_segments = list_child_segments(segment, check_bracketed)
         for sub_segment in sub_segments:
-            # if sub_segment.type == "function":
-            #     function_content = sub_segment.segments[1]
-            #     for child in list_child_segments(function_content.segments[0]):
-            #         res, alias = SqlFluffColumn._get_column_and_alias(child)
-            #         columns += res if res else []
-            # el
             if sub_segment.type == "alias_expression":
                 alias = extract_identifier(sub_segment)
             elif sub_segment.type in SOURCE_COLUMN_SEGMENT_TYPE or is_wildcard(


### PR DESCRIPTION
Closes https://github.com/reata/sqllineage/issues/644

Since [SQLFluff 3.2.0](https://github.com/sqlfluff/sqlfluff/releases/tag/3.2.0), "the bracketed arguments are now wrapped in a `function_contents` object". I adjusted the code base so that it works again.