### PR TITLE
feat: improve performance on large SQL/graphs

### DIFF
--- a/docs/gear_up/configuration.rst
+++ b/docs/gear_up/configuration.rst
@@ -90,6 +90,24 @@ Default: ``False``
 
 Since: 1.4.8
 
+GRAPH_OPERATOR_CLASS
+====================
+A rustworkx graph operator implementation is available since v1.5.7. Set this config to
+``sqllineage.core.graph.rustworkx.RustworkXGraphOperator`` to enable it for better performance, in particular
+when handling large lineage graphs.
+
+SQLLineage uses networkx as default graph operator implementation. Any import errors when using other graph operator
+will fallback to networkx implementation.
+
+.. note::
+     This is an experimental feature. Based on our test suite, rustworkx graph operator shows significant performance
+     improvement over networkx implementation and passes all tests. However, there might be edge cases not covered
+     by our tests. Please report any issues you encounter when using rustworkx graph operator.
+
+Default: ``sqllineage.core.graph.networkx.NetworkXGraphOperator``
+
+Since: 1.5.7
+
 
 .. _Amazon Redshift announces support for lateral column alias reference: https://aws.amazon.com/about-aws/whats-new/2018/08/amazon-redshift-announces-support-for-lateral-column-alias-reference/
 .. _Support "lateral column alias references" to allow column aliases to be used within SELECT clauses: https://issues.apache.org/jira/browse/SPARK-27561

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,10 @@ build-backend = "hatchling.build"
 name = "sqllineage"
 dependencies = [
     "sqlparse>=0.5.4",
-    "networkx>=2.4",
     "sqlfluff>=3.2.0",
     "sqlalchemy>=2.0.0",
+    "networkx>=2.4",
+    "rustworkx>=0.16.0",
 ]
 requires-python = ">=3.10"
 authors = [

--- a/sqllineage/config.py
+++ b/sqllineage/config.py
@@ -20,6 +20,11 @@ class _SQLLineageConfigLoader:
         "TSQL_NO_SEMICOLON": (bool, False),
         # lateral column alias reference supported by some dialect (redshift, spark 3.4+, etc)
         "LATERAL_COLUMN_ALIAS_REFERENCE": (bool, False),
+        # graph operator implementation class
+        "GRAPH_OPERATOR_CLASS": (
+            str,
+            "sqllineage.core.graph.networkx.NetworkXGraphOperator",
+        ),
     }
 
     def __init__(self) -> None:

--- a/sqllineage/core/graph/__init__.py
+++ b/sqllineage/core/graph/__init__.py
@@ -1,0 +1,26 @@
+import importlib
+import logging
+import typing
+
+from sqllineage.config import SQLLineageConfig
+from sqllineage.core.graph.networkx import NetworkXGraphOperator
+
+logger = logging.getLogger(__name__)
+
+
+def get_graph_operator_class() -> type:
+    try:
+        path = SQLLineageConfig.GRAPH_OPERATOR_CLASS.rsplit(".", 1)
+        if len(path) == 1:
+            raise ImportError
+        module_path, class_name = path
+        module = importlib.import_module(module_path)
+        if not hasattr(module, class_name):
+            raise ImportError
+        return typing.cast(type, getattr(module, class_name))
+    except ImportError:
+        logger.warning(
+            "Failed to import %s, using default NetworkXGraphOperator",
+            SQLLineageConfig.GRAPH_OPERATOR_CLASS,
+        )
+        return NetworkXGraphOperator

--- a/sqllineage/core/graph/networkx.py
+++ b/sqllineage/core/graph/networkx.py
@@ -7,7 +7,15 @@ from sqllineage.utils.constant import EdgeDirection
 from sqllineage.utils.entities import EdgeTuple
 
 
-class NetworkXGraphOperator(GraphOperator):
+class NetworkXGraphOperator(GraphOperator[T]):
+    """
+    networkx based implementation of GraphOperator.
+
+    networkx allows any hashable object to be added as a node, so T can be any hashable type.
+
+    networkx edge has a native support for edge type, which we use to store edge label.
+    """
+
     def __init__(self, graph: nx.DiGraph = None) -> None:
         if graph is None:
             self.graph = nx.DiGraph()
@@ -95,10 +103,10 @@ class NetworkXGraphOperator(GraphOperator):
     def drop_edge(self, src_vertex: T, tgt_vertex: T) -> None:
         self.graph.remove_edge(src_vertex, tgt_vertex)
 
-    def get_sub_graph(self, *vertices) -> "NetworkXGraphOperator":
+    def get_sub_graph(self, *vertices) -> "NetworkXGraphOperator[T]":
         return NetworkXGraphOperator(self.graph.subgraph(vertices))
 
-    def merge(self, other: GraphOperator) -> None:
+    def merge(self, other: GraphOperator[T]) -> None:
         if isinstance(other, NetworkXGraphOperator):
             self.graph = nx.compose(self.graph, other.graph)
         else:

--- a/sqllineage/core/graph/rustworkx.py
+++ b/sqllineage/core/graph/rustworkx.py
@@ -1,0 +1,288 @@
+from typing import Any
+
+import rustworkx as rx
+
+from sqllineage.core.graph_operator import GraphOperator, T
+from sqllineage.utils.constant import EdgeDirection
+from sqllineage.utils.entities import EdgeTuple
+
+
+class RustworkXGraphOperator(GraphOperator[T]):
+    """
+    rustworkx based implementation of GraphOperator
+
+    node added to rustworkx graph can only be accessed by index, and it doesn't distinguish nodes vs nodes attributes.
+    For the implementation, each vertex T is represented as a dict with at least one key "vertex" to hold the actual
+    vertex object, e.g., {vertex: T, prop1: val1, ...}, and we will maintain a mapping from vertex T to its node index
+    in the graph
+
+    edge added to rustworkx does not have the concept of label, so we will store label as part of edge data,
+    e.g., {label: str, prop1: val1, ...}
+    """
+
+    def __init__(self, graph: rx.PyDiGraph = None) -> None:
+        if graph is None:
+            self.graph = rx.PyDiGraph()
+            self._vertex_to_index: dict[T, int] = {}
+        else:
+            self.graph = graph
+            # Rebuild vertex mapping from existing graph using actual node indices
+            self._vertex_to_index = {}
+            for node_idx in self.graph.node_indices():
+                node_data = self.graph[node_idx]
+                self._vertex_to_index[node_data["vertex"]] = node_idx
+
+    def add_vertex_if_not_exist(self, vertex: T, **props) -> None:
+        if vertex in self._vertex_to_index:
+            # Update existing node
+            node_idx = self._vertex_to_index[vertex]
+            node_data = self.graph[node_idx]
+            node_data.update(props)
+            self.graph[node_idx] = node_data
+        else:
+            # Add new node
+            node_data = {"vertex": vertex, **props}
+            node_idx = self.graph.add_node(node_data)
+            self._vertex_to_index[vertex] = node_idx
+
+    def retrieve_vertices_by_props(self, **props) -> list[T]:
+        vertices = []
+        for node_idx in self.graph.node_indices():
+            node_data = self.graph[node_idx]
+            if all(node_data.get(prop) == val for prop, val in props.items()):
+                vertices.append(node_data["vertex"])
+        return vertices
+
+    def retrieve_source_vertices(self) -> list[T]:
+        return [
+            self.graph[node_idx]["vertex"]
+            for node_idx in self.graph.node_indices()
+            if len(self.graph.in_edges(node_idx)) == 0
+            and len(self.graph.out_edges(node_idx)) > 0
+        ]
+
+    def retrieve_target_vertices(self) -> list[T]:
+        return [
+            self.graph[node_idx]["vertex"]
+            for node_idx in self.graph.node_indices()
+            if len(self.graph.in_edges(node_idx)) > 0
+            and len(self.graph.out_edges(node_idx)) == 0
+        ]
+
+    def retrieve_selfloop_vertices(self) -> list[T]:
+        return [
+            self.graph[node_idx]["vertex"]
+            for node_idx in self.graph.node_indices()
+            if self.graph.has_edge(node_idx, node_idx)
+        ]
+
+    def update_vertices(self, *vertices: T, **props) -> None:
+        for vertex in vertices:
+            if vertex in self._vertex_to_index:
+                node_idx = self._vertex_to_index[vertex]
+                node_data = self.graph[node_idx]
+                node_data.update(props)
+                self.graph[node_idx] = node_data
+
+    def drop_vertices(self, *vertices: T) -> None:
+        indices_to_remove = []
+        for vertex in vertices:
+            # remove from mapping and collect indices to remove
+            if (idx := self._vertex_to_index.pop(vertex, None)) is not None:
+                indices_to_remove.append(idx)
+        self.graph.remove_nodes_from(indices_to_remove)
+
+    def add_edge_if_not_exist(
+        self, src_vertex: T, tgt_vertex: T, label: str, **props
+    ) -> None:
+        if src_vertex is not None and tgt_vertex is not None:
+            src_idx = self._vertex_to_index.get(src_vertex)
+            tgt_idx = self._vertex_to_index.get(tgt_vertex)
+            if src_idx is None:
+                src_idx = self.graph.add_node({"vertex": src_vertex})
+                self._vertex_to_index[src_vertex] = src_idx
+            if tgt_idx is None:
+                tgt_idx = self.graph.add_node({"vertex": tgt_vertex})
+                self._vertex_to_index[tgt_vertex] = tgt_idx
+            edge_data = {"label": label, **props}
+            if not self.graph.has_edge(src_idx, tgt_idx):
+                self.graph.add_edge(src_idx, tgt_idx, edge_data)
+
+    def retrieve_edges_by_label(self, label: str) -> list[EdgeTuple]:
+        edges = []
+        for src_idx, tgt_idx in self.graph.edge_list():
+            edge_data = self.graph.get_edge_data(src_idx, tgt_idx)
+            if edge_data["label"] == label:
+                attribute = edge_data.copy()
+                attribute.pop("label")
+                edges.append(
+                    EdgeTuple(
+                        source=self.graph[src_idx]["vertex"],
+                        target=self.graph[tgt_idx]["vertex"],
+                        label=label,
+                        attributes=attribute,
+                    )
+                )
+        return edges
+
+    def retrieve_edges_by_vertex(
+        self, vertex: T, direction: str, label: str | None = None
+    ) -> list[EdgeTuple]:
+        edges: list[EdgeTuple] = []
+        vertex_idx = self._vertex_to_index.get(vertex)
+        if vertex_idx is None:
+            return edges
+
+        # rustworkx returns in_edges and out_edges in reverse insertion order
+        # we want to return in insertion order to match the behavior of NetworkX
+        if direction == EdgeDirection.IN:
+            edge_list = reversed(self.graph.in_edges(vertex_idx))
+        else:
+            edge_list = reversed(self.graph.out_edges(vertex_idx))
+
+        # Collect edges and sort by (source_idx, target_idx) for deterministic ordering
+        for src_idx, tgt_idx, edge_data in edge_list:
+            if label is None or edge_data.get("label") == label:
+                src_node = self.graph[src_idx]
+                tgt_node = self.graph[tgt_idx]
+                src_vertex = (
+                    src_node.get("vertex") if isinstance(src_node, dict) else src_node
+                )
+                tgt_vertex = (
+                    tgt_node.get("vertex") if isinstance(tgt_node, dict) else tgt_node
+                )
+                label = edge_data["label"]
+                attributes = edge_data.copy()
+                attributes.pop("label")
+                edges.append(
+                    EdgeTuple(
+                        source=src_vertex,
+                        target=tgt_vertex,
+                        label=label,
+                        attributes=attributes,
+                    )
+                )
+
+        return edges
+
+    def drop_edge(self, src_vertex: T, tgt_vertex: T) -> None:
+        src_idx = self._vertex_to_index.get(src_vertex)
+        tgt_idx = self._vertex_to_index.get(tgt_vertex)
+        if (
+            src_idx is not None
+            and tgt_idx is not None
+            and self.graph.has_edge(src_idx, tgt_idx)
+        ):
+            self.graph.remove_edge(src_idx, tgt_idx)
+
+    def get_sub_graph(self, *vertices: T) -> "RustworkXGraphOperator[T]":
+        indices = [
+            self._vertex_to_index[vertex]
+            for vertex in vertices
+            if vertex in self._vertex_to_index
+        ]
+        return RustworkXGraphOperator(self.graph.subgraph(indices))
+
+    def merge(self, other: GraphOperator[T]) -> None:
+        if isinstance(other, RustworkXGraphOperator):
+            # Create a mapping from other's indices to self's indices
+            index_mapping = {}
+
+            # Add all nodes from other graph
+            for other_idx in other.graph.node_indices():
+                node_data = other.graph[other_idx]
+                vertex = node_data["vertex"]
+                if vertex not in self._vertex_to_index:
+                    new_idx = self.graph.add_node(node_data)
+                    self._vertex_to_index[vertex] = new_idx
+                    index_mapping[other_idx] = new_idx
+                else:
+                    self.graph[self._vertex_to_index[vertex]].update(node_data)
+                    index_mapping[other_idx] = self._vertex_to_index[vertex]
+
+            # Add all edges from other graph
+            for src_idx, tgt_idx in other.graph.edge_list():
+                edge_data = other.graph.get_edge_data(src_idx, tgt_idx)
+                self_src_idx = index_mapping.get(src_idx)
+                self_tgt_idx = index_mapping.get(tgt_idx)
+                if not self.graph.has_edge(self_src_idx, self_tgt_idx):
+                    self.graph.add_edge(self_src_idx, self_tgt_idx, edge_data)
+        else:
+            raise TypeError(
+                "Expect other to be RustworkXGraphOperator, got " + str(type(other))
+            )
+
+    def list_lineage_paths(self, src_vertex: T, tgt_vertex: T) -> list[list[T]]:
+        result = []
+        for path in rx.all_simple_paths(
+            self.graph,
+            self._vertex_to_index.get(src_vertex),
+            self._vertex_to_index.get(tgt_vertex),
+        ):
+            path_vertices = []
+            for idx in path:
+                node_data = self.graph[idx]
+                path_vertices.append(node_data["vertex"])
+            result.append(path_vertices)
+        return result
+
+    def to_cytoscape(
+        self, compound: bool = False
+    ) -> list[dict[str, dict[str, object]]]:
+        if compound:
+            parents_dict = {}
+            for node_idx in self.graph.node_indices():
+                node_data = self.graph[node_idx]
+                vertex = node_data.get("vertex")
+                parent = getattr(vertex, "parent", None)
+                if parent is not None:
+                    parents_dict[parent] = {
+                        "name": str(parent),
+                        "type": type(parent).__name__,
+                    }
+
+            nodes = []
+            for node_idx in self.graph.node_indices():
+                vertex = self.graph[node_idx]["vertex"]
+                parent = getattr(vertex, "parent", None)
+                parent_candidates = getattr(vertex, "parent_candidates", [])
+                nodes.append(
+                    {
+                        "data": {
+                            "id": str(vertex),
+                            "parent": (
+                                parents_dict[parent]["name"]
+                                if parent in parents_dict
+                                else "<unknown>"
+                            ),
+                            "parent_candidates": [
+                                {"name": str(p), "type": type(p).__name__}
+                                for p in parent_candidates
+                            ],
+                            "type": type(vertex).__name__,
+                        }
+                    }
+                )
+
+            nodes += [
+                {"data": {"id": attr["name"], "type": attr["type"]}}
+                for _, attr in parents_dict.items()
+            ]
+        else:
+            nodes = [
+                {"data": {"id": str(self.graph[node_idx]["vertex"])}}
+                for node_idx in self.graph.node_indices()
+            ]
+
+        edges: list[dict[str, dict[str, Any]]] = [
+            {
+                "data": {
+                    "id": f"e{edge_id}",
+                    "source": str(self.graph[src_idx]["vertex"]),
+                    "target": str(self.graph[tgt_idx]["vertex"]),
+                }
+            }
+            for edge_id, (src_idx, tgt_idx) in enumerate(self.graph.edge_list())
+        ]
+
+        return nodes + edges

--- a/sqllineage/core/graph_operator.py
+++ b/sqllineage/core/graph_operator.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from typing import Generic, TypeVar
 
 from sqllineage.utils.entities import EdgeTuple
 
 T = TypeVar("T")
 
 
-class GraphOperator(ABC):
+class GraphOperator(ABC, Generic[T]):
     """
     Base class used to operator the graph structure that holder leverages to store lineage information
     """
@@ -62,7 +62,8 @@ class GraphOperator(ABC):
         self, src_vertex: T, tgt_vertex: T, label: str, **props
     ) -> None:
         """
-        when vertex already exists, props will be updated
+        when source and target vertices do not exist, they will be added to the graph first.
+        when edge already exists, invoking this method should not create duplicate edge.
         """
         raise NotImplementedError
 
@@ -81,11 +82,16 @@ class GraphOperator(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_sub_graph(self, *vertices: T) -> "GraphOperator":
+    def get_sub_graph(self, *vertices: T) -> "GraphOperator[T]":
         raise NotImplementedError
 
     @abstractmethod
-    def merge(self, other: "GraphOperator") -> None:
+    def merge(self, other: "GraphOperator[T]") -> None:
+        """
+        The vertices and edges from other graph will be added to current graph.
+        When vertex or edge already exists, their props will be updated.
+        In case of prop keys conflict, self takes precedence over other.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/sqllineage/core/graph_operator.py
+++ b/sqllineage/core/graph_operator.py
@@ -1,57 +1,55 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any
 
 from sqllineage.utils.entities import EdgeTuple
 
-T = TypeVar("T")
 
-
-class GraphOperator(ABC, Generic[T]):
+class GraphOperator(ABC):
     """
     Base class used to operator the graph structure that holder leverages to store lineage information
     """
 
     @abstractmethod
-    def add_vertex_if_not_exist(self, vertex: T, **props) -> None:
+    def add_vertex_if_not_exist(self, vertex: Any, **props) -> None:
         """
         when vertex already exists, props will be updated
         """
         raise NotImplementedError
 
     @abstractmethod
-    def retrieve_vertices_by_props(self, **props) -> list[T]:
+    def retrieve_vertices_by_props(self, **props) -> list[Any]:
         """
         when props is empty, return all vertices
         """
         raise NotImplementedError
 
     @abstractmethod
-    def retrieve_source_vertices(self) -> list[T]:
+    def retrieve_source_vertices(self) -> list[Any]:
         """
         source vertices are defined as vertices with no incoming edges and at least one outgoing edge
         """
         raise NotImplementedError
 
     @abstractmethod
-    def retrieve_target_vertices(self) -> list[T]:
+    def retrieve_target_vertices(self) -> list[Any]:
         """
         target vertices are defined as vertices with no outgoing edges and at least one incoming edge
         """
         raise NotImplementedError
 
     @abstractmethod
-    def retrieve_selfloop_vertices(self) -> list[T]:
+    def retrieve_selfloop_vertices(self) -> list[Any]:
         """
         self-loop vertices are defined as vertices with edges pointing to themselves
         """
         raise NotImplementedError
 
     @abstractmethod
-    def update_vertices(self, *vertices: T, **props) -> None:
+    def update_vertices(self, *vertices: Any, **props) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def drop_vertices(self, *vertices: T) -> None:
+    def drop_vertices(self, *vertices: Any) -> None:
         """
         drop vertices from the graph if exists
         """
@@ -59,7 +57,7 @@ class GraphOperator(ABC, Generic[T]):
 
     @abstractmethod
     def add_edge_if_not_exist(
-        self, src_vertex: T, tgt_vertex: T, label: str, **props
+        self, src_vertex: Any, tgt_vertex: Any, label: str, **props
     ) -> None:
         """
         when source and target vertices do not exist, they will be added to the graph first.
@@ -73,20 +71,20 @@ class GraphOperator(ABC, Generic[T]):
 
     @abstractmethod
     def retrieve_edges_by_vertex(
-        self, vertex: T, direction: str, label: str | None = None
+        self, vertex: Any, direction: str, label: str | None = None
     ) -> list[EdgeTuple]:
         raise NotImplementedError
 
     @abstractmethod
-    def drop_edge(self, src_vertex: T, tgt_vertex: T) -> None:
+    def drop_edge(self, src_vertex: Any, tgt_vertex: Any) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def get_sub_graph(self, *vertices: T) -> "GraphOperator[T]":
+    def get_sub_graph(self, *vertices: Any) -> "GraphOperator":
         raise NotImplementedError
 
     @abstractmethod
-    def merge(self, other: "GraphOperator[T]") -> None:
+    def merge(self, other: "GraphOperator") -> None:
         """
         The vertices and edges from other graph will be added to current graph.
         When vertex or edge already exists, their props will be updated.
@@ -95,7 +93,7 @@ class GraphOperator(ABC, Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def list_lineage_paths(self, src_vertex: T, tgt_vertex: T) -> list[list[T]]:
+    def list_lineage_paths(self, src_vertex: Any, tgt_vertex: Any) -> list[list[Any]]:
         """
         list all lineage paths (acyclic) in the graph from src_vertex to tgt_vertex.
         """

--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -1,6 +1,6 @@
 import itertools
 
-from sqllineage.core.graph.networkx import NetworkXGraphOperator
+from sqllineage.core.graph import get_graph_operator_class
 from sqllineage.core.graph_operator import GraphOperator
 from sqllineage.core.metadata_provider import MetaDataProvider
 from sqllineage.core.models import Column, Path, Schema, SubQuery, Table
@@ -60,7 +60,7 @@ class SubQueryLineageHolder(ColumnLineageMixin):
     """
 
     def __init__(self) -> None:
-        self.go = NetworkXGraphOperator()
+        self.go = get_graph_operator_class()()
 
     def __or__(self, other):
         self.go.merge(other.go)
@@ -334,7 +334,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         """
         The table level GraphOperator held by SQLLineageHolder
         """
-        table_nodes = [  # type: ignore[var-annotated]
+        table_nodes = [
             v
             for v in self.go.retrieve_vertices_by_props()
             if isinstance(v, DATASET_CLASSES)
@@ -346,7 +346,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         """
         The column level GraphOperator held by SQLLineageHolder
         """
-        column_nodes = [  # type: ignore[var-annotated]
+        column_nodes = [
             v for v in self.go.retrieve_vertices_by_props() if isinstance(v, Column)
         ]
         return self.go.get_sub_graph(*column_nodes)
@@ -399,7 +399,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         return intermediate_tables
 
     def __retrieve_tag_tables(self, tag) -> set[Path | Table]:
-        return {  # type: ignore[var-annotated]
+        return {
             vertex
             for vertex in self.go.retrieve_vertices_by_props(**{tag: True})
             if isinstance(vertex, DATASET_CLASSES)
@@ -411,7 +411,7 @@ class SQLLineageHolder(ColumnLineageMixin):
         To assemble multiple :class:`sqllineage.core.holders.StatementLineageHolder` into
         :class:`sqllineage.core.holders.SQLLineageHolder`
         """
-        ngo = NetworkXGraphOperator()
+        ngo = get_graph_operator_class()()
         for holder in args:
             ngo.merge(holder.go)
             if holder.drop:

--- a/tests/core/test_graph_operator.py
+++ b/tests/core/test_graph_operator.py
@@ -1,0 +1,34 @@
+import pytest
+
+from sqllineage.config import SQLLineageConfig
+from sqllineage.core.graph import get_graph_operator_class
+from sqllineage.core.graph.networkx import NetworkXGraphOperator
+from sqllineage.core.graph.rustworkx import RustworkXGraphOperator
+
+
+def test_graph_operator_dummy():
+    with pytest.raises(TypeError):
+        NetworkXGraphOperator().merge(RustworkXGraphOperator())
+    with pytest.raises(TypeError):
+        RustworkXGraphOperator().merge(NetworkXGraphOperator())
+
+
+def test_graph_operator_import():
+    assert get_graph_operator_class() == NetworkXGraphOperator
+    with SQLLineageConfig(
+        GRAPH_OPERATOR_CLASS="sqllineage.core.graph.rustworkx.RustworkXGraphOperator"
+    ):
+        assert get_graph_operator_class() == RustworkXGraphOperator
+
+
+def test_graph_operator_import_fail():
+    with SQLLineageConfig(GRAPH_OPERATOR_CLASS="invalid_format"):
+        assert get_graph_operator_class() == NetworkXGraphOperator
+    with SQLLineageConfig(
+        GRAPH_OPERATOR_CLASS="sqllineage.core.graph.invalid_module.UnknownGraphOperator"
+    ):
+        assert get_graph_operator_class() == NetworkXGraphOperator
+    with SQLLineageConfig(
+        GRAPH_OPERATOR_CLASS="sqllineage.core.graph.networkx.UnknownGraphOperator"
+    ):
+        assert get_graph_operator_class() == NetworkXGraphOperator

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -2,22 +2,25 @@ import os
 import tempfile
 
 from sqllineage.cli import main
+from sqllineage.config import SQLLineageConfig
 from sqllineage.core.models import SubQuery
 from sqllineage.runner import LineageRunner
 from sqllineage.utils.constant import LineageLevel
 
-from ..helpers import assert_table_lineage_equal
+from ..helpers import _gen_graph_operators, assert_table_lineage_equal
 
 
 def test_runner_dummy():
-    runner = LineageRunner(
-        """insert into tab2 select col1, col2, col3, col4, col5, col6 from tab1;
-insert into tab3 select * from tab2""",
-        verbose=True,
-    )
-    assert str(runner)
-    assert runner.to_cytoscape() is not None
-    assert runner.to_cytoscape(level=LineageLevel.COLUMN) is not None
+    for graph_operator in _gen_graph_operators():
+        with SQLLineageConfig(GRAPH_OPERATOR_CLASS=graph_operator):
+            runner = LineageRunner(
+                """insert into tab2 select col1, col2, col3, col4, col5, col6 from tab1;
+        insert into tab3 select * from tab2""",
+                verbose=True,
+            )
+            assert str(runner)
+            assert runner.to_cytoscape() is not None
+            assert runner.to_cytoscape(level=LineageLevel.COLUMN) is not None
 
 
 def test_statements_trim_comment():


### PR DESCRIPTION
As discussed in https://github.com/reata/sqllineage/discussions/679, I've done a first draft of minimal changes to speed up the column level lineage identification.

I think we should keep `networkx` - it's more powerful and flexible - and just switch to `rustworkx` where needed for performance reason.

Keen to hear your thoughts!