### PR TITLE
feat: support parsing stored procedures for bigquery dialect

### DIFF
--- a/sqllineage/core/parser/sqlfluff/analyzer.py
+++ b/sqllineage/core/parser/sqlfluff/analyzer.py
@@ -91,9 +91,18 @@ class SqlFluffLineageAnalyzer(LineageAnalyzer):
                 f"{sql}\n"
                 f"{violation_msg}"
             )
+        supported_types = []
+        for extractor_cls in BaseExtractor.__subclasses__():
+            supported_types.extend(extractor_cls.SUPPORTED_STMT_TYPES)
         segments = []
         for top_segment in getattr(parsed.tree, "segments", []):
             match top_segment.type:
+                case "multi_statement_segment":
+                    for statement in top_segment.segments[0].recursive_crawl(
+                        "statement"
+                    ):
+                        if statement.segments[0].type in supported_types:
+                            segments.append(statement.segments[0])
                 case "statement":
                     segments.append(top_segment.segments[0])
                 case "batch":

--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -190,7 +190,11 @@ Target Tables:
                 self._file_path, self._dialect, self._silent_mode
             )
         )
-        if SQLLineageConfig.TSQL_NO_SEMICOLON and self._dialect == "tsql":
+        if (
+            SQLLineageConfig.TSQL_NO_SEMICOLON
+            and self._dialect == "tsql"
+            or self._dialect == "bigquery"
+        ):
             self._stmt = analyzer.split_tsql(self._sql.strip())
         else:
             if SQLLineageConfig.TSQL_NO_SEMICOLON and self._dialect != "tsql":

--- a/tests/sql/column/multiple_statements/test_column_from_procedure_dialect_specific.py
+++ b/tests/sql/column/multiple_statements/test_column_from_procedure_dialect_specific.py
@@ -1,0 +1,58 @@
+import pytest
+
+from sqllineage.utils.entities import ColumnQualifierTuple
+
+from ....helpers import assert_column_lineage_equal
+
+
+@pytest.mark.parametrize("dialect", ["bigquery"])
+def test_lineage_column_from_procedure(dialect: str):
+    sql = """CREATE PROCEDURE `test-lineage-bq`.dataset_a.sp_test (
+  param_a INT64, param_b DATE
+)
+BEGIN
+  DECLARE var_a INT64 DEFAULT 0;
+  IF param_a IS NULL THEN
+    SET param_a = 0;
+  ELSEIF param_a < 0 THEN
+    SET param_a = ABS(param_a);
+  END IF;
+  SET param_b = COALESCE(param_b, CURRENT_DATE('Asia/Shanghai'));
+  LOOP
+    SET var_a = var_a + 1;
+    INSERT INTO `test-lineage-bq.dataset_a.table_c`
+    SELECT
+      a.col1 AS id_pk,
+      a.col2 AS updated,
+      b.col2 AS pet
+    FROM test-lineage-bq.dataset_a.table_a AS a
+    LEFT JOIN test-lineage-bq.dataset_a.table_b AS b
+      ON a.col1 = b.col1
+    WHERE DATE(a.col2) >= param_b;
+    SELECT @@ROW_COUNT AS aff_rows;
+    IF var_a >= param_a THEN LEAVE;
+    END IF;
+  END LOOP;
+EXCEPTION WHEN ERROR THEN
+  SELECT @@ERROR.MESSAGE AS error_info;
+  RAISE;
+END;"""
+    assert_column_lineage_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "test-lineage-bq.dataset_a.table_a"),
+                ColumnQualifierTuple("id_pk", "test-lineage-bq.dataset_a.table_c"),
+            ),
+            (
+                ColumnQualifierTuple("col2", "test-lineage-bq.dataset_a.table_a"),
+                ColumnQualifierTuple("updated", "test-lineage-bq.dataset_a.table_c"),
+            ),
+            (
+                ColumnQualifierTuple("col2", "test-lineage-bq.dataset_a.table_b"),
+                ColumnQualifierTuple("pet", "test-lineage-bq.dataset_a.table_c"),
+            ),
+        ],
+        dialect=dialect,
+        test_sqlparse=False,
+    )


### PR DESCRIPTION
Address (in part, and specifically for bigquery dialect) what was asked in Discussion #556 and Issue #643.

The task is accomplished by adding the case for `multi_statement_segment` in
method `_list_specific_statement_segment` from class `SqlFluffLineageAnalyzer`
combined with the method `recursive_crawl("statement")` to extract all statements
from multi statement segments and a filter for processing only the statement types
supported by sqllineage (no warnings or exceptions as procedures can contain
many statements meaningless for lineage construction).

To cope with many statements inside a multi statement segment, the parse and
cache strategy from `analyzer.split_tsql()` method was leveraged (probably this
method should be renamed as it seems this approach can be useful for parsing
procedures from other dialects).


This pull request is in draft mode as I just made parsing stored procedures for bigquery dialect to work.
Any thoughts are welcome for getting this PR ready for merge.
