### PR TITLE
fix: handle different sqlfluff parse result for DDL in sparksql

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -96,8 +96,18 @@ class CreateInsertExtractor(BaseExtractor):
                         columns = []
                         for sub_segment in sub_segments:
                             if sub_segment.type == "column_definition":
+                                # sqlfluff's column_definition parse tree varies by dialect:
+                                #  for most dialect:
+                                #     column_definition -> identifier
+                                #  for sparksql, databricks since sqlfluff 3.2.5):
+                                #     column_definition -> column_reference -> identifier
+                                # We try identifier first, then fall back to column_reference.
                                 if identifier := sub_segment.get_child("identifier"):
                                     sub_segment = identifier
+                                elif column_ref := sub_segment.get_child(
+                                    "column_reference"
+                                ):
+                                    sub_segment = column_ref
                             columns.append(SqlFluffColumn.of(sub_segment))
                         holder.add_write_column(*columns)
 

--- a/tests/sql/column/test_column_select_column_specified_in_dml_dialect_specific.py
+++ b/tests/sql/column/test_column_select_column_specified_in_dml_dialect_specific.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sqllineage.utils.entities import ColumnQualifierTuple
+
+from ...helpers import assert_column_lineage_equal
+
+
+@pytest.mark.parametrize("dialect", ["databricks", "sparksql"])
+def test_column_lineage_with_column_type_definitions(dialect: str):
+    """
+    CTAS with column type definitions should produce clean column names in lineage.
+
+    sqlfluff's column_definition parse tree differs by dialect:
+      ANSI, bigquery, postgres, ... : column_definition → identifier
+      sparksql, databricks          : column_definition → column_reference → identifier
+    """
+    sql = """CREATE TABLE target_tbl(
+   col_a string,
+   col_b string)
+AS
+SELECT col1 AS col_a,
+       col2 AS col_b
+FROM source_tbl"""
+    assert_column_lineage_equal(
+        sql,
+        [
+            (
+                ColumnQualifierTuple("col1", "source_tbl"),
+                ColumnQualifierTuple("col_a", "target_tbl"),
+            ),
+            (
+                ColumnQualifierTuple("col2", "source_tbl"),
+                ColumnQualifierTuple("col_b", "target_tbl"),
+            ),
+        ],
+        dialect=dialect,
+        test_sqlparse=False,
+    )


### PR DESCRIPTION
Close #757 