### PR TITLE
fix: insert into given MetaDataProvider still use source name as target column name

### DIFF
--- a/sqllineage/core/holders.py
+++ b/sqllineage/core/holders.py
@@ -237,9 +237,11 @@ class SubQueryLineageHolder(ColumnLineageMixin):
         wildcard_in_union: bool = False,
     ) -> None:
         target_columns = self.get_table_columns(tgt_table)
+        use_positional = wildcard_in_union or (
+            len(target_columns) == len(src_table_columns)
+        )
         for idx, src_col in enumerate(src_table_columns):
-            # Prefer positional mapping only when enabled (e.g., subsequent UNION arms)
-            if wildcard_in_union and idx < len(target_columns):
+            if use_positional and idx < len(target_columns):
                 target_col = target_columns[idx]
             else:
                 # otherwise, if target column with same name exists (union scenario), reuse it; or create a new one

--- a/sqllineage/core/parser/sqlparse/analyzer.py
+++ b/sqllineage/core/parser/sqlparse/analyzer.py
@@ -240,6 +240,18 @@ class SqlParseLineageAnalyzer(LineageAnalyzer):
                 if next_handler.indicator:
                     next_handler.handle(sub_token, holder)
         else:
+            # populate target table columns from metadata for INSERT statement
+            if (
+                isinstance(token, Statement)
+                and token.get_type() == "INSERT"
+                and metadata_provider
+            ):
+                if tgt_tbl := holder._get_target_table():
+                    if isinstance(tgt_tbl, Table) and not holder.get_table_columns(
+                        tgt_tbl
+                    ):
+                        tgt_columns = metadata_provider.get_table_columns(tgt_tbl)
+                        holder.add_write_column(*tgt_columns)
             # call end of query hook here as loop is over
             for next_handler in next_handlers:
                 next_handler.end_of_query_cleanup(holder)

--- a/tests/sql/column/test_metadata_target_column.py
+++ b/tests/sql/column/test_metadata_target_column.py
@@ -63,7 +63,6 @@ from date.date"""
             ),
         ],
         metadata_provider=provider,
-        test_sqlparse=False,
     )
 
 
@@ -128,5 +127,4 @@ SELECT date_key, dd, prd, ndd, pydd, pyoydd, dow, down, dom, doy FROM cte_table"
             ),
         ],
         metadata_provider=provider,
-        test_sqlparse=False,
     )

--- a/tests/sql/column/test_metadata_wildcard.py
+++ b/tests/sql/column/test_metadata_wildcard.py
@@ -578,5 +578,4 @@ FROM temp.dim_credit_card"""
         ],
         dialect=dialect,
         metadata_provider=provider,
-        test_sqlparse=False,  # Only test with sqlfluff as sqlparse doesn't handle write_column
     )


### PR DESCRIPTION
Close #635 