### PR TITLE
fix: quoted identifier with dots should not be split as schema.table

### DIFF
--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -50,18 +50,18 @@ class Table:
         :param name: table name
         :param schema: schema as defined by :class:`Schema`
         """
-        if "." not in name:
-            self.schema = schema
-            self.raw_name = escape_identifier_name(name)
-        else:
+        escaped = kwargs.pop("escaped", False)
+        if not escaped and "." in name:
             schema_name, table_name = name.rsplit(".", 1)
             if len(schema_name.split(".")) > 2:
-                # allow db.schema as schema_name, but a.b.c as schema_name is forbidden
                 raise SQLLineageException("Invalid format for table name: %s.", name)
             self.schema = Schema(schema_name)
             self.raw_name = escape_identifier_name(table_name)
             if schema:
                 warnings.warn("Name is in schema.table format, schema param is ignored")
+        else:
+            self.schema = schema
+            self.raw_name = name if escaped else escape_identifier_name(name)
         self.alias = escape_identifier_name(kwargs.pop("alias", self.raw_name))
 
     def __str__(self):

--- a/sqllineage/core/parser/sqlfluff/extractors/base.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/base.py
@@ -62,11 +62,10 @@ class BaseExtractor:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def find_table(segment: BaseSegment) -> Table | None:
+    def find_table(self, segment: BaseSegment) -> Table | None:
         table = None
         if segment.type in ["table_reference", "object_reference"]:
-            table = SqlFluffTable.of(segment)
+            table = SqlFluffTable.of(segment, dialect=self.dialect)
         return table
 
     @staticmethod
@@ -125,9 +124,8 @@ class BaseExtractor:
 
         return tables
 
-    @staticmethod
     def _add_dataset_from_expression_element(
-        segment: BaseSegment, holder: SubQueryLineageHolder
+        self, segment: BaseSegment, holder: SubQueryLineageHolder
     ) -> list[Table | SubQuery | Path]:
         """
         Append tables and subqueries identified in the 'from_expression_element' type segment to the table and
@@ -195,7 +193,11 @@ class BaseExtractor:
                             )
                         )
                     else:
-                        tables.append(SqlFluffTable.of(table_identifier, alias=alias))
+                        tables.append(
+                            SqlFluffTable.of(
+                                table_identifier, alias=alias, dialect=self.dialect
+                            )
+                        )
 
         return tables
 

--- a/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/create_insert.py
@@ -131,7 +131,7 @@ class CreateInsertExtractor(BaseExtractor):
 
             if tgt_flag:
                 if segment.type in ["table_reference", "object_reference"]:
-                    write_obj = SqlFluffTable.of(segment)
+                    write_obj = SqlFluffTable.of(segment, dialect=self.dialect)
                     holder.add_write(write_obj)
                     # get target table columns from metadata if available
                     if (
@@ -159,7 +159,7 @@ class CreateInsertExtractor(BaseExtractor):
                 tgt_flag = False
             if src_flag:
                 if segment.type in ["table_reference", "object_reference"]:
-                    holder.add_read(SqlFluffTable.of(segment))
+                    holder.add_read(SqlFluffTable.of(segment, dialect=self.dialect))
                 src_flag = False
         return holder
 

--- a/sqllineage/core/parser/sqlfluff/models.py
+++ b/sqllineage/core/parser/sqlfluff/models.py
@@ -39,11 +39,14 @@ class SqlFluffTable(Table):
     """
 
     @staticmethod
-    def of(table: BaseSegment, alias: str | None = None) -> Table:
+    def of(
+        table: BaseSegment, alias: str | None = None, dialect: str = "ansi"
+    ) -> Table:
         """
         Build an object of type 'Table'
         :param table: table segment to be processed
         :param alias: alias of the table segment
+        :param dialect: sql dialect
         :return: 'Table' object
         """
         dot_idx = None
@@ -52,7 +55,7 @@ class SqlFluffTable(Table):
             if bool(token.type == "symbol"):
                 dot_idx, _ = idx, token
                 break
-        real_name = (
+        real_name = escape_identifier_name(
             table.segments[dot_idx + 1].raw
             if dot_idx
             else (table.raw if table.type == "identifier" else table.segments[0].raw)
@@ -70,7 +73,15 @@ class SqlFluffTable(Table):
         )
         schema = Schema(parent_name) if parent_name is not None else Schema()
         kwargs = {"alias": alias} if alias else {}
-        return Table(real_name, schema, **kwargs)
+        if dot_idx is None:
+            # no dot-symbol found, dots are inside a quoted identifier
+            # for most dialects dots are literal characters in the name;
+            # BigQuery is the exception — backtick-quoted dots remain separators
+            escaped = dialect != "bigquery"
+        else:
+            # dot-symbol found, .of() already decomposed schema and table name
+            escaped = True
+        return Table(real_name, schema, escaped=escaped, **kwargs)
 
 
 class SqlFluffSubQuery(SubQuery):

--- a/sqllineage/core/parser/sqlparse/models.py
+++ b/sqllineage/core/parser/sqlparse/models.py
@@ -31,7 +31,22 @@ class SqlParseTable(Table):
             start=len(table.tokens),
             reverse=True,
         )
-        real_name = table._get_first_name(dot_idx, real_name=True)
+        if dot_idx:
+            # scan forward from the dot to find the name token, preserving
+            # quotes for case sensitivity (e.g., schema."MyTable" → MyTable)
+            real_name = None
+            for token in table.tokens[dot_idx + 1 :]:
+                if token.ttype in (T.Name, T.Wildcard, T.Literal.String.Symbol):
+                    real_name = escape_identifier_name(token.value)
+                    break
+            if real_name is None:
+                real_name = escape_identifier_name(
+                    table._get_first_name(dot_idx, real_name=True)
+                )
+        else:
+            # use raw token value instead of _get_first_name to preserve
+            # quoting info (e.g., "1.2.3.SomeTable" → 1.2.3.SomeTable)
+            real_name = escape_identifier_name(table.tokens[0].value)
         # rewrite identifier's get_parent_name accordingly
         parent_name = (
             "".join(
@@ -46,7 +61,7 @@ class SqlParseTable(Table):
         schema = Schema(parent_name) if parent_name is not None else Schema()
         alias = table.get_alias()
         kwargs = {"alias": alias} if alias else {}
-        return Table(real_name, schema, **kwargs)
+        return Table(real_name, schema, escaped=True, **kwargs)
 
 
 class SqlParseSubQuery(SubQuery):

--- a/tests/sql/table/test_select.py
+++ b/tests/sql/table/test_select.py
@@ -1,3 +1,7 @@
+import pytest
+
+from sqllineage.core.models import Schema, Table
+
 from ...helpers import assert_table_lineage_equal
 
 
@@ -366,3 +370,26 @@ def test_non_reserved_keyword_as_source():
 
 def test_select_in_parenthesis():
     assert_table_lineage_equal("(SELECT * FROM tab1)", {"tab1"}, test_sqlparse=False)
+
+
+def test_select_from_quoted_table_with_dots():
+    """quoted identifier with dots is a single table name, not schema.table"""
+    assert_table_lineage_equal(
+        'SELECT * FROM "1.2.3.SomeTable"',
+        {Table("1.2.3.SomeTable", escaped=True)},
+    )
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ('SELECT * FROM "MyTable"', {Table("MyTable", escaped=True)}),
+        (
+            'SELECT * FROM schema."MyTable"',
+            {Table("MyTable", Schema("schema"), escaped=True)},
+        ),
+    ],
+)
+def test_select_from_quoted_table_preserves_case(sql: str, expected: set[Table]):
+    """quoted table name is case-sensitive, not lowercased"""
+    assert_table_lineage_equal(sql, expected)

--- a/tests/sql/table/test_select_dialect_specific.py
+++ b/tests/sql/table/test_select_dialect_specific.py
@@ -128,3 +128,20 @@ def test_tsql_table_hints(dialect: str):
     """
     sql = "select * from dbname.dto.tablename(NOLOCK)"
     assert_table_lineage_equal(sql, {"dbname.dto.tablename"}, dialect=dialect)
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT * FROM `proj.dataset.tbl`", {"proj.dataset.tbl"}),
+        ("SELECT * FROM `proj`.`dataset`.`tbl`", {"proj.dataset.tbl"}),
+        ("SELECT * FROM `my-project`.`dataset`.`tbl`", {"my-project.dataset.tbl"}),
+        ("SELECT * FROM `dataset.tbl`", {"dataset.tbl"}),
+    ],
+)
+def test_select_from_backtick_quoted_multi_part_path(sql: str, expected: set[str]):
+    """
+    BigQuery backtick-quoted table path: dots remain separators.
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifiers
+    """
+    assert_table_lineage_equal(sql, expected, dialect="bigquery", test_sqlparse=False)


### PR DESCRIPTION
Close #787 