### PR TITLE
perf: cache Table/Column __str__ and __hash__ to avoid repeated recomputation

### DIFF
--- a/sqllineage/core/models.py
+++ b/sqllineage/core/models.py
@@ -63,9 +63,11 @@ class Table:
             self.schema = schema
             self.raw_name = name if escaped else escape_identifier_name(name)
         self.alias = escape_identifier_name(kwargs.pop("alias", self.raw_name))
+        self._str_cache = f"{self.schema}.{self.raw_name}"
+        self._hash_cache = hash(self._str_cache)
 
     def __str__(self):
-        return f"{self.schema}.{self.raw_name}"
+        return self._str_cache
 
     def __repr__(self):
         return "Table: " + str(self)
@@ -74,7 +76,7 @@ class Table:
         return isinstance(other, Table) and str(self) == str(other)
 
     def __hash__(self):
-        return hash(str(self))
+        return self._hash_cache
 
     @staticmethod
     def of(table: Any) -> "Table":
@@ -167,11 +169,17 @@ class Column:
         self.from_alias = kwargs.pop("from_alias", False)
 
     def __str__(self):
-        return (
-            f"{self.parent}.{self.raw_name}"
-            if self.parent is not None and not isinstance(self.parent, Path)
-            else f"{self.raw_name}"
-        )
+        try:
+            return self._str_cache
+        except AttributeError:
+            p = self.parent
+            result = (
+                f"{p}.{self.raw_name}"
+                if p is not None and not isinstance(p, Path)
+                else self.raw_name
+            )
+            self._str_cache = result
+            return result
 
     def __repr__(self):
         return "Column: " + str(self)
@@ -184,7 +192,11 @@ class Column:
         )
 
     def __hash__(self):
-        return hash(str(self))
+        try:
+            return self._hash_cache
+        except AttributeError:
+            result = self._hash_cache = hash(str(self))
+            return result
 
     @property
     def parent(self) -> Path | Table | SubQuery | None:
@@ -193,6 +205,8 @@ class Column:
     @parent.setter
     def parent(self, value: Path | Table | SubQuery):
         self._parent.add(value)
+        self.__dict__.pop("_str_cache", None)
+        self.__dict__.pop("_hash_cache", None)
 
     @property
     def parent_candidates(self) -> list[Path | Table | SubQuery]:


### PR DESCRIPTION
## Summary

`Table` and `Column` are hashed and stringified very frequently during lineage resolution, in set membership checks, graph node lookups, and deduplication, yet `__str__` and `__hash__` recomputed their result from scratch on every single call. Profiling large workloads showed this recomputation as a significant, avoidable cost, since the underlying data these methods depend on rarely, if ever, changes after construction.

This PR caches `Table.__str__`/`__hash__` and `Column.__str__`/`__hash__` instead of recomputing them each time. `Table`'s cache is computed once in `__init__`, since `schema` and `raw_name` never change afterward. `Column`'s cache is populated lazily on first access and invalidated whenever `Column.parent` is set, since `parent` is assigned after construction and can change. The result is a broad, low risk speedup with no behavior change.

## Performance

Custom benchmark suite ([bench.py](https://github.com/user-attachments/files/30086218/bench.py)), before versus after:

| Benchmark | Before (s) | After (s) | Delta |
| --- | --- | --- | --- |
| wide | 60.531 | 23.985 | reduced 60.39% |
| many | 7.949 | 4.375 | reduced 44.97% |
| athena | 114.095 | 96.972 | reduced 15.01% |

With `wide` and `many` being pathological tests, and `athena` being an internal production scenario. [CodSpeed](https://app.codspeed.io/tobycraft/sqllineage/runs/compare/6a58bd500547a28bc90f53e7..6a588a2e7355afc16259ca3f?uri=benchmarks%2Fcodspeed%2Ftest_tpcds_print_column_lineage.py%3A%3Atest_tpcds_print_column_lineage&runnerMode=WallTime
)  (`benchmarks/codspeed/test_tpcds_print_column_lineage.py`):

- `test_tpcds_print_column_lineage`: 192.6s to 130.7s, improved 47%
- `test_tpcds_print_column_lineage_rustworkx`: 94.2s to 92.2s, improved 2%

The networkx variant gains far more because `nx.DiGraph` stores its adjacency as a plain Python dict keyed by the `Table`/`Column` objects themselves, so nearly every graph operation calls `__hash__`/`__str__` on them repeatedly. The rustworkx backend only keeps a thin vertex-to-index Python dict; once a vertex has an index, traversal and edge storage happen inside the Rust core on integer indices, so there is far less redundant hashing for this change to remove.