### PR TITLE
fix: unquote tsql bracket identifier containing a quote char

### DIFF
--- a/sqllineage/utils/helpers.py
+++ b/sqllineage/utils/helpers.py
@@ -12,14 +12,16 @@ def escape_identifier_name(name: str):
     Reference: https://stackoverflow.com/a/19933159
     """
     quote_chars = ["`", '"', "'"]
-    if any(quote_char in name for quote_char in quote_chars):
+    if name.startswith("[") and name.endswith("]"):
+        # tsql allows quoted identifier with square brackets, see reference
+        # https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16#classes-of-identifiers
+        # check brackets first so a bracketed identifier containing a quote char
+        # (e.g. [O'Brien]) is still correctly unquoted
+        return name.strip("[]")
+    elif any(quote_char in name for quote_char in quote_chars):
         for quote_char in quote_chars:
             name = name.strip(quote_char)
         return name
-    elif name.startswith("[") and name.endswith("]"):
-        # tsql allows quoted identifier with square brackets, see reference
-        # https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16#classes-of-identifiers
-        return name.strip("[]")
     else:
         return name.lower()
 

--- a/tests/sql/table/test_select_dialect_specific.py
+++ b/tests/sql/table/test_select_dialect_specific.py
@@ -35,6 +35,12 @@ def test_select_with_schema_in_bracket(dialect: str):
     )
 
 
+@pytest.mark.parametrize("dialect", ["tsql"])
+def test_select_with_bracket_identifier_containing_quote(dialect: str):
+    # a bracketed identifier that contains a quote char must still be unquoted
+    assert_table_lineage_equal("SELECT * FROM [O'Brien]", {"O'Brien"}, dialect=dialect)
+
+
 @pytest.mark.parametrize("dialect", ["databricks", "hive", "sparksql"])
 def test_select_left_semi_join(dialect: str):
     assert_table_lineage_equal(


### PR DESCRIPTION
escape_identifier_name checked for quote chars before the tsql square-bracket branch, so a bracketed identifier containing a quote (e.g. [O'Brien]) matched the quote branch and kept its brackets. Check brackets first. Adds a regression test.