### PR TITLE
fix: capture subquery in scalar projection and CASE ELSE branch

### DIFF
--- a/sqllineage/core/parser/sqlfluff/utils.py
+++ b/sqllineage/core/parser/sqlfluff/utils.py
@@ -169,6 +169,37 @@ def list_subqueries(segment: BaseSegment) -> list[SubQueryTuple]:
                                     else None
                                 )
                                 subquery.append(SubQueryTuple(bracketed_segment, alias))
+                        # subquery living in the ELSE branch of a CASE expression
+                        if else_clause := case_expression.get_child("else_clause"):
+                            if else_expression := else_clause.get_child("expression"):
+                                for bracketed in else_expression.get_children(
+                                    "bracketed"
+                                ):
+                                    if is_subquery(bracketed):
+                                        subquery.append(
+                                            SubQueryTuple(
+                                                extract_innermost_bracketed(bracketed),
+                                                None,
+                                            )
+                                        )
+                    else:
+                        # scalar subquery used directly as a projected column,
+                        # e.g. SELECT (SELECT max(x) FROM b) AS m FROM a
+                        for bracketed in expression.get_children("bracketed"):
+                            if is_subquery(bracketed):
+                                alias_expression = select_clause_element.get_child(
+                                    "alias_expression"
+                                )
+                                alias = (
+                                    extract_identifier(alias_expression)
+                                    if alias_expression
+                                    else None
+                                )
+                                subquery.append(
+                                    SubQueryTuple(
+                                        extract_innermost_bracketed(bracketed), alias
+                                    )
+                                )
                 elif function := select_clause_element.get_child("function"):
                     for bracketed in function.recursive_crawl("bracketed"):
                         if is_subquery(bracketed):

--- a/tests/sql/table/test_select.py
+++ b/tests/sql/table/test_select.py
@@ -197,6 +197,21 @@ WHERE col1 IN (SELECT max(col1) FROM tab2)""",
     )
 
 
+def test_select_scalar_subquery_in_projection():
+    assert_table_lineage_equal(
+        "SELECT (SELECT max(col1) FROM tab1) AS c1, col2 FROM tab2",
+        {"tab1", "tab2"},
+    )
+
+
+def test_select_subquery_in_case_else():
+    assert_table_lineage_equal(
+        "SELECT CASE WHEN col1 = 1 THEN col2 "
+        "ELSE (SELECT max(col3) FROM tab2) END AS c FROM tab1",
+        {"tab1", "tab2"},
+    )
+
+
 def test_select_subquery_in_function():
     assert_table_lineage_equal(
         "SELECT TO_DATE((SELECT MIN(dt) FROM tab1))",


### PR DESCRIPTION
list_subqueries only handled CASE WHEN/THEN and function-wrapped subqueries, dropping the source table of a scalar sub-select used directly as a projected column and of a subquery in a CASE ELSE branch. Both are now collected, matching the sqlparse parser. Adds two table-level regression tests.