### PR TITLE
fix: keep column lineage for tsql UPDATE/MERGE when SET RHS is wrapped in expression

### DIFF
--- a/sqllineage/core/parser/sqlfluff/extractors/merge.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/merge.py
@@ -46,7 +46,20 @@ class MergeExtractor(BaseExtractor):
                             for set_clause in set_clause_list.get_children(
                                 "set_clause"
                             ):
-                                columns = set_clause.get_children("column_reference")
+                                columns = list(
+                                    set_clause.get_children("column_reference")
+                                )
+                                if len(columns) == 1:
+                                    # tsql wraps the RHS of an assignment in an
+                                    # `expression` segment
+                                    if expression := set_clause.get_child("expression"):
+                                        expr_children = list_child_segments(expression)
+                                        if (
+                                            len(expr_children) == 1
+                                            and expr_children[0].type
+                                            == "column_reference"
+                                        ):
+                                            columns.append(expr_children[0])
                                 if len(columns) == 2:
                                     src_col = tgt_col = None
                                     if src_cqt := extract_column_qualifier(columns[1]):

--- a/sqllineage/core/parser/sqlfluff/extractors/update.py
+++ b/sqllineage/core/parser/sqlfluff/extractors/update.py
@@ -55,7 +55,18 @@ class UpdateExtractor(BaseExtractor):
 
             if segment.type == "set_clause_list":
                 for set_clause in segment.get_children("set_clause"):
-                    column_references = set_clause.get_children("column_reference")
+                    column_references = list(
+                        set_clause.get_children("column_reference")
+                    )
+                    if len(column_references) == 1:
+                        # tsql wraps the RHS of an assignment in an `expression` segment
+                        if expression := set_clause.get_child("expression"):
+                            expr_children = list_child_segments(expression)
+                            if (
+                                len(expr_children) == 1
+                                and expr_children[0].type == "column_reference"
+                            ):
+                                column_references.append(expr_children[0])
                     if len(column_references) == 2:
                         tgt_cqt = extract_column_qualifier(column_references[0])
                         src_cqt = extract_column_qualifier(column_references[1])

--- a/tests/sql/column/test_column_merge.py
+++ b/tests/sql/column/test_column_merge.py
@@ -123,3 +123,16 @@ WHEN NOT MATCHED THEN INSERT (k, v) VALUES (b.k, b.v_max)"""
         dialect="tsql",
         test_sqlparse=False,
     )
+
+
+def test_merge_into_update_tsql():
+    # tsql wraps the assignment RHS in an `expression` segment, so the
+    # UPDATE SET source column of a MERGE used to be dropped
+    sql = """MERGE INTO target USING src ON target.id = src.id
+WHEN MATCHED THEN UPDATE SET target.v = src.v"""
+    assert_column_lineage_equal(
+        sql,
+        [(ColumnQualifierTuple("v", "src"), ColumnQualifierTuple("v", "target"))],
+        dialect="tsql",
+        test_sqlparse=False,
+    )

--- a/tests/sql/column/test_column_update.py
+++ b/tests/sql/column/test_column_update.py
@@ -159,3 +159,15 @@ def test_column_update_with_subquery():
         ],
         test_sqlparse=False,
     )
+
+
+def test_column_update_tsql_alias_target_column():
+    # tsql wraps the assignment RHS in an `expression` segment, so the
+    # source column of `SET t.c = s.c` used to be dropped
+    sql = "UPDATE t SET t.c = s.c FROM tab1 t JOIN tab2 s ON t.id = s.id"
+    assert_column_lineage_equal(
+        sql,
+        [(ColumnQualifierTuple("c", "tab2"), ColumnQualifierTuple("c", "tab1"))],
+        dialect="tsql",
+        test_sqlparse=False,
+    )


### PR DESCRIPTION
In tsql the right-hand side of an assignment is wrapped in an `expression` segment, so set_clause exposes only one direct column_reference and the len==2 guard skipped the source->target edge. Unwrap a single-column-reference expression RHS in both UpdateExtractor and MergeExtractor, with regression tests.