### PR TITLE
fix: use path containment check instead of string prefix in drawing server

### DIFF
--- a/sqllineage/drawing.py
+++ b/sqllineage/drawing.py
@@ -81,9 +81,9 @@ class SQLLineageApp:
                     request_body = environ["wsgi.input"].read(request_body_size)
                     payload = json.loads(request_body)
                     for param in ["d", "f"]:
-                        if param in payload and not str(
-                            Path(payload[param]).absolute()
-                        ).startswith(str(Path(self.root_path).absolute())):
+                        if param in payload and not Path(
+                            payload[param]
+                        ).resolve().is_relative_to(Path(self.root_path).resolve()):
                             return self.handle_403(start_response)
                     data = self.routes[path_info](payload)
                     return self.handle_200_json(start_response, data)

--- a/tests/core/test_drawing.py
+++ b/tests/core/test_drawing.py
@@ -66,6 +66,9 @@ def test_handler():
     assert container.status.startswith(str(HTTPStatus.FORBIDDEN.value))
     mock_request("POST", "/directory", {"d": "/"})
     assert container.status.startswith(str(HTTPStatus.FORBIDDEN.value))
+    # a sibling directory that merely shares the root's string prefix is not inside it
+    mock_request("POST", "/directory", {"d": SQLLineageConfig.DIRECTORY + "_evil"})
+    assert container.status.startswith(str(HTTPStatus.FORBIDDEN.value))
     # 404
     mock_request("GET", "/non-exist-resource")
     assert container.status.startswith(str(HTTPStatus.NOT_FOUND.value))


### PR DESCRIPTION
The POST d/f parameter guard used str.startswith, which accepts a sibling directory that merely shares the root's string prefix. Use Path.resolve().is_relative_to for a real containment check. Adds a regression test.