### PR TITLE
docs: fix column lineage examples and verbose output order

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ Statement #1: insert into db1.table1 select * from db2.table2;
     table read: [Table: db2.table2]
     table write: [Table: db1.table1]
     table cte: []
-    table rename: []
     table drop: []
+    table rename: []
 Statement #2: insert into db3.table3 select * from db1.table1;
     table read: [Table: db1.table1]
     table write: [Table: db3.table3]
     table cte: []
-    table rename: []
     table drop: []
+    table rename: []
 ==========
 Summary:
 Statements(#): 2
@@ -140,7 +140,7 @@ FROM bar a
          LEFT JOIN (SELECT bar_id, sum(col3) AS col3_sum
                     FROM qux
                     GROUP BY bar_id) c
-                   ON a.id = sq.bar_id
+                   ON a.id = c.bar_id
          CROSS JOIN quux d;
 
 INSERT INTO corge
@@ -177,14 +177,14 @@ Suppose all the tables are created in sqlite database with a file called `db.db`
 table `quux` has columns `col5` and `col6` and `baz` has column `col4`. 
 ```shell
 sqlite3 db.db 'CREATE TABLE IF NOT EXISTS baz (bar_id int, col1 int, col4 int)';
-sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (quux_id int, col5 int, col6 int)';
+sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (col5 int, col6 int)';
 ```
 
 Now given the same SQL, column lineage is fully resolved.
 ```shell
 $ SQLLINEAGE_DEFAULT_SCHEMA=main sqllineage -f test.sql -l column --sqlalchemy_url=sqlite:///db.db
 main.corge.col1 <- main.foo.col1 <- main.bar.col1
-main.corge.col2 <- main.foo.col2 <- main.bar.col1
+main.corge.col2 <- main.foo.col2 <- main.baz.col1
 main.corge.col2 <- main.grault.col2
 main.foo.col3 <- c.col3_sum <- main.qux.col3
 main.foo.col4 <- main.baz.col4

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ col4 could be coming from `bar`, `baz` or `quux`. Without metadata, this is the 
 User can optionally provide the metadata information to sqllineage to improve the lineage result.
 
 Suppose all the tables are created in sqlite database with a file called `db.db`. In particular, 
-table `quux` has columns `col5` and `col6` and `baz` has column `col4`. 
+tables `baz` and `quux` are created with the following schema:
 ```shell
 sqlite3 db.db 'CREATE TABLE IF NOT EXISTS baz (bar_id int, col1 int, col4 int)';
-sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (col5 int, col6 int)';
+sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (quux_id int, col5 int, col6 int)';
 ```
 
 Now given the same SQL, column lineage is fully resolved.
@@ -190,6 +190,7 @@ main.foo.col3 <- c.col3_sum <- main.qux.col3
 main.foo.col4 <- main.baz.col4
 main.foo.col5 <- main.quux.col5
 main.foo.col6 <- main.quux.col6
+main.foo.quux_id <- main.quux.quux_id
 ```
 The default schema name in sqlite is called `main`, we have to specify here because the tables in SQL file are unqualified.
 

--- a/docs/first_steps/advanced_usage.rst
+++ b/docs/first_steps/advanced_usage.rst
@@ -31,14 +31,14 @@ And if you want to see lineage for each SQL statement, just toggle verbose optio
         table read: [Table: db2.table2]
         table write: [Table: db1.table1]
         table cte: []
-        table rename: []
         table drop: []
+        table rename: []
     Statement #2: insert into db3.table3 select * from db1.table1;
         table read: [Table: db1.table1]
         table write: [Table: db3.table3]
         table cte: []
-        table rename: []
         table drop: []
+        table rename: []
     ==========
     Summary:
     Statements(#): 2
@@ -102,7 +102,7 @@ will be printed.
              LEFT JOIN (SELECT bar_id, sum(col3) AS col3_sum
                         FROM qux
                         GROUP BY bar_id) c
-                       ON a.id = sq.bar_id
+                       ON a.id = c.bar_id
              CROSS JOIN quux d;
 
     INSERT INTO corge
@@ -145,7 +145,7 @@ table `quux` has columns `col5` and `col6` and `baz` has column `col4`.
 .. code-block:: bash
 
     sqlite3 db.db 'CREATE TABLE IF NOT EXISTS baz (bar_id int, col1 int, col4 int)';
-    sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (quux_id int, col5 int, col6 int)';
+    sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (col5 int, col6 int)';
 
 Now given the same SQL, column lineage is fully resolved.
 
@@ -153,7 +153,7 @@ Now given the same SQL, column lineage is fully resolved.
 
     $ SQLLINEAGE_DEFAULT_SCHEMA=main sqllineage -f test.sql -l column --sqlalchemy_url=sqlite:///db.db
     main.corge.col1 <- main.foo.col1 <- main.bar.col1
-    main.corge.col2 <- main.foo.col2 <- main.bar.col1
+    main.corge.col2 <- main.foo.col2 <- main.baz.col1
     main.corge.col2 <- main.grault.col2
     main.foo.col3 <- c.col3_sum <- main.qux.col3
     main.foo.col4 <- main.baz.col4

--- a/docs/first_steps/advanced_usage.rst
+++ b/docs/first_steps/advanced_usage.rst
@@ -140,12 +140,12 @@ col4 could be coming from `bar`, `baz` or `quux`. Without metadata, this is the 
 User can optionally provide the metadata information to sqllineage to improve the lineage result.
 
 Suppose all the tables are created in sqlite database with a file called `db.db`. In particular,
-table `quux` has columns `col5` and `col6` and `baz` has column `col4`.
+tables `baz` and `quux` are created with the following schema:
 
 .. code-block:: bash
 
     sqlite3 db.db 'CREATE TABLE IF NOT EXISTS baz (bar_id int, col1 int, col4 int)';
-    sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (col5 int, col6 int)';
+    sqlite3 db.db 'CREATE TABLE IF NOT EXISTS quux (quux_id int, col5 int, col6 int)';
 
 Now given the same SQL, column lineage is fully resolved.
 
@@ -159,6 +159,7 @@ Now given the same SQL, column lineage is fully resolved.
     main.foo.col4 <- main.baz.col4
     main.foo.col5 <- main.quux.col5
     main.foo.col6 <- main.quux.col6
+    main.foo.quux_id <- main.quux.quux_id
 
 The default schema name in sqlite is called `main`, we have to specify here because the tables in SQL file are unqualified.
 

--- a/docs/gear_up/metadata.rst
+++ b/docs/gear_up/metadata.rst
@@ -31,6 +31,7 @@ User can instantiate DummyMetaDataProvider with metadata dict of their own inste
     main.foo.col1 <- main.bar.col1
     main.foo.col2 <- main.bar.col2
     >>> sql2 = "insert into main.foo select * from main.baz"
+    >>> LineageRunner(sql2, metadata_provider=provider).print_column_lineage()
     main.foo.* <- main.baz.*
 
 DummyMetaDataProvider is mostly used for testing purposes. The demo above shows that when there is another SQL query like


### PR DESCRIPTION
Correct the MetaData example (foo.col2 comes from baz not bar; quux has only col5/col6; add the missing print_column_lineage call), fix the undefined sq alias in the column example, and swap the verbose table drop/rename lines to match actual output. Examples now reproduce verbatim.