### PR TITLE
refactor: use flex layout to size editor panel without magic numbers

### DIFF
--- a/sqllineagejs/src/App.jsx
+++ b/sqllineagejs/src/App.jsx
@@ -246,6 +246,9 @@ export default function App() {
             left: drawerWidth + 0.6 + "vw",
           }}
         />
+        {/* The fixed AppBar (dense Toolbar) is 48px = theme.spacing(6); the
+            marginTop below and the calc(100vh - spacing(6)) height are
+            coupled to that value and must change together. */}
         <Box
           component="main"
           sx={(theme) => ({
@@ -261,7 +264,7 @@ export default function App() {
         >
           <Paper
             elevation="24"
-            sx={{ flexGrow: 1, minHeight: 0 }}
+            sx={{ flexGrow: 1, minHeight: "240px" }}
             style={{ width: width }}
           >
             <Box sx={viewSelected === "dag" ? { height: "100%" } : { display: "none" }}>

--- a/sqllineagejs/src/App.jsx
+++ b/sqllineagejs/src/App.jsx
@@ -73,12 +73,6 @@ export default function App() {
   );
   const isResizing = React.useRef(false);
 
-  // Reserve space for the fixed AppBar (marginTop: theme.spacing(6) = 48px),
-  // the main box padding (theme.spacing(0.5) = 4px top/bottom), and the
-  // view-toggle radio row below the paper (~42px), so the paper fills the
-  // remaining viewport instead of overflowing it (which caused a permanent
-  // vertical scrollbar on shorter windows).
-  const height = "calc(100vh - 98px)";
   const width = useMemo(() => {
     let full_width = 100;
     return (drawerOpen ? full_width - drawerWidth : full_width) + "vw";
@@ -259,20 +253,28 @@ export default function App() {
             marginTop: theme.spacing(6),
             float: "right",
             marginLeft: drawerOpen ? drawerWidth + "vw" : theme.spacing(0),
+            display: "flex",
+            flexDirection: "column",
+            height: `calc(100vh - ${theme.spacing(6)})`,
+            boxSizing: "border-box",
           })}
         >
-          <Paper elevation="24" style={{ height: height, width: width }}>
-            <Box sx={viewSelected === "dag" ? {} : { display: "none" }}>
-              <DAG height={height} width={width} />
+          <Paper
+            elevation="24"
+            sx={{ flexGrow: 1, minHeight: 0 }}
+            style={{ width: width }}
+          >
+            <Box sx={viewSelected === "dag" ? { height: "100%" } : { display: "none" }}>
+              <DAG height="100%" width={width} />
             </Box>
-            <Box sx={viewSelected === "text" ? {} : { display: "none" }}>
-              <DAGDesc height={height} width={width} />
+            <Box sx={viewSelected === "text" ? { height: "100%" } : { display: "none" }}>
+              <DAGDesc height="100%" width={width} />
             </Box>
-            <Box sx={viewSelected === "script" ? {} : { display: "none" }}>
-              <Editor height={height} width={width} dialect={dialectSelected} />
+            <Box sx={viewSelected === "script" ? { height: "100%" } : { display: "none" }}>
+              <Editor height="100%" width={width} dialect={dialectSelected} />
             </Box>
           </Paper>
-          <Grid container sx={{ justifyContent: "center" }}>
+          <Grid container sx={{ justifyContent: "center", flexShrink: 0 }}>
             <FormControl variant="standard" component="fieldset">
               <RadioGroup
                 row

--- a/sqllineagejs/src/features/editor/DAG.jsx
+++ b/sqllineagejs/src/features/editor/DAG.jsx
@@ -326,7 +326,7 @@ export function DAG(props) {
     ];
     const style = { width: props.width, height: props.height };
     return (
-      <div style={{ height: "100%" }}>
+      <div style={{ height: props.height }}>
         <CytoscapeComponent
           elements={editorState.dagContent}
           stylesheet={stylesheet}

--- a/sqllineagejs/src/features/editor/DAG.jsx
+++ b/sqllineagejs/src/features/editor/DAG.jsx
@@ -326,7 +326,7 @@ export function DAG(props) {
     ];
     const style = { width: props.width, height: props.height };
     return (
-      <div>
+      <div style={{ height: "100%" }}>
         <CytoscapeComponent
           elements={editorState.dagContent}
           stylesheet={stylesheet}


### PR DESCRIPTION
Replace the hard-coded calc(100vh - 98px) with a flex column layout so the editor paper fills the viewport below the fixed AppBar and the view-toggle row, eliminating the permanent vertical scrollbar on shorter windows. Verified at 500-1080px viewport heights (DAG/Monaco fill the paper, no page overflow).