### PR TITLE
Add wraps decorator to lazy_method function

### DIFF
--- a/sqllineage/runner.py
+++ b/sqllineage/runner.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from collections import OrderedDict
+from functools import wraps
 from typing import Any
 
 from sqllineage import DEFAULT_DIALECT, SQLPARSE_DIALECT
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def lazy_method(func):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         self = args[0]
         if not self._evaluated:


### PR DESCRIPTION
`lazy_method`/`lazy_property` don't preserve the wrapped function's `__name__`/`__doc__`, which breaks Sphinx autodoc and IDE tooltips for every decorated method. This has been the case since the decorators were introduced. Adding `functools.wraps` is a one-line, behavior-preserving fix which improves introspection and IDE support.