### PR TITLE
chore: migrate dev/docs dependencies to PEP 735 dependency groups

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,15 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.11"
+    python: "latest"
+  # Install the project itself plus the PEP 735 `docs` dependency group.
+  # See https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-from-dependency-groups
+  jobs:
+    install:
+      - pip install --upgrade pip
+      - pip install --group 'docs' .
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,12 +24,3 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
-
-# We recommend specifying your dependencies to enable reproducible builds:
-# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -2,7 +2,6 @@
 Hatch build hook for building frontend assets.
 """
 
-import os
 import platform
 import shlex
 import shutil
@@ -29,8 +28,6 @@ class FrontendBuildHook(BuildHookInterface):
            then install from sdist. sdist itself does not include built static files, same as source code repo.
            Installation from sdist will trigger this hook. (by building a wheel from sdist)
         """
-        if "READTHEDOCS" in os.environ:
-            return
         py_path = Path("sqllineage")
         static_folder = "build"
         static_path = py_path / static_folder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
-ci = [
+[dependency-groups]
+dev = [
     "black>=26.1.0",
     "mypy>=1.19.0",
     "pytest>=8.4.1",
@@ -78,11 +78,11 @@ path = "sqllineage/__init__.py"
 path = "hatch_build.py"
 
 [tool.tox]
-requires = ["tox>=4.19"]
+requires = ["tox>=4.28.4"]
 env_list = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.tox.env_run_base]
-deps = [".[ci]"]
+dependency_groups = ["dev"]
 commands = [
     ["black", ".", "--check", "--diff"],
     ["ruff", "check", "."],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ requires = ["tox>=4.28.4"]
 env_list = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.tox.env_run_base]
+deps = ["."]
 dependency_groups = ["dev"]
 commands = [
     ["black", ".", "--check", "--diff"],


### PR DESCRIPTION
## Summary

Migrate the `ci`/`docs` optional-dependencies to PEP 735 `[dependency-groups]`, so these CI/docs-only dependency sets are no longer exposed in the published package metadata as installable extras (`pip install sqllineage[ci]` / `sqllineage[docs]` will no longer work — they were never meant for end users).

### Commit 1: migrate dev and docs dependencies to PEP 735 dependency groups

- **pyproject.toml**
  - Replace `[project.optional-dependencies]` (`ci`/`docs`) with top-level `[dependency-groups]` (`dev`/`docs`). Dependency groups live only in `pyproject.toml` and never enter the wheel/sdist metadata.
  - tox: `deps = [".[ci]"]` → `dependency_groups = ["dev"]` (tox auto-installs the project itself, so behavior is unchanged), and align `[tool.tox] requires` with the group's `tox>=4.28.4` (was `4.19`; `dependency_groups` needs tox ≥ 4.22).
- **.readthedocs.yml**
  - Read the Docs has no native config key for dependency groups, so the official `build.jobs.install` approach is used: `pip install --group 'docs' .` (pip ≥ 25.1). The trailing `.` is required because `docs/conf.py` imports `sqllineage` and Sphinx autodoc imports modules that pull in the runtime dependencies.
  - `os: ubuntu-lts-latest` / `python: "latest"` intentionally float with the newest LTS / latest Python on Read the Docs.

### Commit 2: drop READTHEDOCS special case in frontend build hook

`hatch_build.py` already degrades gracefully when `npm` is missing (see #772), and Read the Docs build images don't ship Node.js unless `build.tools.nodejs` is declared. The `READTHEDOCS` env-var early return is therefore redundant and has been removed (together with the now-unused `import os`).

## Validation

- `pyproject.toml` / `.readthedocs.yml` parse OK; `tox c -e py` resolves `dependency_groups = dev`.
- pre-commit hooks (black/ruff/mypy) pass.
- RTD builds will print the expected "npm is not available, skipping frontend build" warning; worth watching the first docs build after merge.
