### PR TITLE
chore: revert temporary rustworkx upper bound for 0.18.0 regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "sqlfluff>=3.2.0",
     "sqlalchemy>=1.4.0",
     "networkx>=2.4",
-    "rustworkx>=0.16.0,<0.18.0",
+    "rustworkx>=0.16.0",
 ]
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
Reverts #782 (commit e491b09ec153ef22b53c8cc182b9d7bf8e371850).

The upstream regression ([Qiskit/rustworkx#1617](https://github.com/Qiskit/rustworkx/issues/1617), `all_simple_paths` returning empty list for self-loops) has been fixed and released in rustworkx 0.18.1, so the temporary `<0.18.0` upper bound is no longer needed.

This restores the dependency spec to `rustworkx>=0.16.0`.