### PR TITLE
fix: download artifacts to explicit path for pypi publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,8 @@ jobs:
         python -m build
     - uses: actions/upload-artifact@v7
       with:
-        path: ./dist
+        name: python-package-distributions
+        path: dist/
   pypi-publish:
     needs: ['build']
     runs-on: ubuntu-latest
@@ -31,7 +32,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: artifact/
+          packages-dir: dist/


### PR DESCRIPTION
pypi-publish job fails with "no Python distribution packages in 'artifact/'" since actions were bumped to v7/v8 (#777). download-artifact@v8 extracts a run's only artifact directly into the workspace instead of an artifact-named directory, so `packages-dir: artifact/` no longer resolves. Use the canonical pattern: same explicit artifact `name` on upload and download, download into `dist/`, publish from `dist/`.